### PR TITLE
Add docker build/push/test scripts

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -41,10 +41,13 @@ docker pull mrcide/daedalus.api:latest
 
 # run the container
 # see docker run --help for options
-docker run -d --rm -p 8001:8001 daedalus.api:latest
+docker run -d --name daedalus-api --rm -p 8001:8001 mrcide/daedalus.api:latest
 
 # check root endpoint `GET/`
 curl -s http://localhost:8001 | jq
+
+# stop the service
+docker stop daedalus-api
 ```
 
 Instructions to build directly from this repository will be added soon.

--- a/README.Rmd
+++ b/README.Rmd
@@ -20,6 +20,7 @@ knitr::opts_chunk$set(
 [![CRAN status](https://www.r-pkg.org/badges/version/daedalus.api)](https://CRAN.R-project.org/package=daedalus.api)
 [![Codecov test coverage](https://codecov.io/gh/j-idea/daedalus.api/branch/main/graph/badge.svg)](https://app.codecov.io/gh/j-idea/daedalus.api?branch=main)
 [![R-CMD-check](https://github.com/j-idea/daedalus.api/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/j-idea/daedalus.api/actions/workflows/R-CMD-check.yaml)
+[![Build status](https://badge.buildkite.com/2fe5d34f1b4c4681b4e0e8d464f4fdaf44358fc48325b92580.svg)](https://buildkite.com/mrc-ide/daedalus-dot-api)
 <!-- badges: end -->
 
 _daedalus.api_ is an API package for the [_daedalus_ package](https://github.com/jameel-institute/daedalus) and is primarily intended for internal use.

--- a/README.Rmd
+++ b/README.Rmd
@@ -35,12 +35,9 @@ devtools::install_github("jameel-institute/daedalus.api")
 
 ## Quick start
 
-Clone this repository and run the following command from the repository directory to build the Docker image described by `docker/Dockerfile`.
-You will need [Docker Engine](https://docs.docker.com/engine/) for this. You may also need `sudo` permissions.
-
 ```sh
 # the image will be assigned the tag 'latest'
-docker build . -f docker/Dockerfile -t daedalus.api:latest
+docker pull mrcide/daedalus.api:latest
 
 # run the container
 # see docker run --help for options

--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -1,0 +1,13 @@
+steps:
+  - label: ":whale::rstats: Build"
+    command: docker/build
+
+  - wait
+
+  - label: ":docker: Docker connection test"
+    command: docker/test_connection
+
+  - wait
+
+  - label: ":shipit: Push images"
+    command: docker/push

--- a/docker/build
+++ b/docker/build
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -ex
+HERE=$(dirname $0)
+. $HERE/common
+
+docker build --pull \
+       --tag $TAG_SHA \
+       -f docker/Dockerfile \
+       .
+
+# We always push the SHA tagged versions, for debugging if the tests
+# after this step fail
+docker push $TAG_SHA

--- a/docker/common
+++ b/docker/common
@@ -1,0 +1,28 @@
+# -*-sh-*-
+PACKAGE_ROOT=$(realpath $HERE/..)
+PACKAGE_NAME=$(cat $PACKAGE_ROOT/DESCRIPTION | \
+                      grep '^Package:' | sed 's/^.*: *//')
+PACKAGE_ORG=mrcide
+PACKAGE_VERSION=$(cat $PACKAGE_ROOT/DESCRIPTION | \
+                      grep '^Version:' | sed 's/^.*: *//')
+
+# Buildkite doesn't check out a full history from the remote (just the
+# single commit) so you end up with a detached head and git rev-parse
+# doesn't work
+if [ "$BUILDKITE" = "true" ]; then
+    GIT_SHA=${BUILDKITE_COMMIT:0:7}
+else
+    GIT_SHA=$(git -C "$PACKAGE_ROOT" rev-parse --short=7 HEAD)
+fi
+
+
+if [ "$BUILDKITE" = "true" ]; then
+    GIT_BRANCH=$BUILDKITE_BRANCH
+else
+    GIT_BRANCH=$(git -C "$PACKAGE_ROOT" symbolic-ref --short HEAD)
+fi
+
+TAG_SHA="${PACKAGE_ORG}/${PACKAGE_NAME}:${GIT_SHA}"
+TAG_BRANCH="${PACKAGE_ORG}/${PACKAGE_NAME}:${GIT_BRANCH}"
+TAG_VERSION="${PACKAGE_ORG}/${PACKAGE_NAME}:v${PACKAGE_VERSION}"
+TAG_LATEST="${PACKAGE_ORG}/${PACKAGE_NAME}:latest"

--- a/docker/push
+++ b/docker/push
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+HERE=$(dirname $0)
+. $HERE/common
+
+# In case we switch agents between steps
+[ ! -z $(docker images -q $TAG_SHA) ] || docker pull $TAG_SHA
+
+docker tag $TAG_SHA $TAG_BRANCH
+docker push $TAG_BRANCH
+
+if [ $GIT_BRANCH == "master" ]; then
+   docker tag $TAG_SHA $TAG_LATEST
+   docker tag $TAG_SHA $TAG_VERSION
+   docker push $TAG_LATEST
+   docker push $TAG_VERSION
+fi

--- a/docker/push
+++ b/docker/push
@@ -9,7 +9,7 @@ HERE=$(dirname $0)
 docker tag $TAG_SHA $TAG_BRANCH
 docker push $TAG_BRANCH
 
-if [ $GIT_BRANCH == "master" ]; then
+if [ $GIT_BRANCH == "main" ]; then
    docker tag $TAG_SHA $TAG_LATEST
    docker tag $TAG_SHA $TAG_VERSION
    docker push $TAG_LATEST

--- a/docker/test_connection
+++ b/docker/test_connection
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -ex
+HERE=$(dirname $0)
+. $HERE/common
+
+# In case we switch agents between steps
+[ ! -z $(docker images -q $TAG_SHA) ] || docker pull $TAG_SHA
+
+NAME_SERVER=daedalus-api
+
+function cleanup {
+    echo "Cleaning up"
+    docker kill $NAME_SERVER > /dev/null || true
+}
+
+trap cleanup EXIT
+
+docker run --rm -d -p 8001:8001 --name $NAME_SERVER $TAG_SHA
+
+set +e
+for attempt in $(seq 10); do
+    echo "Attempt $attempt"
+    RESPONSE=$(curl --silent http://localhost:8001)
+    if [[ "$RESPONSE" == *"success"* ]]; then
+        echo "SUCCESS"
+        exit 0
+    fi
+    sleep 1
+done
+
+echo "FAIL"
+exit 1


### PR DESCRIPTION
This PR merges into #1, not main.

This PR sets up our normal docker approach.  At some point I'd like to explore using github's container registry (gcr) because dockerhub is quite annoying to work with.  A consequence of this annoyingness is that the namespace here is `mrcide` because that's the one we have a (fairly tenuous) pro account on.

The instructions as posted won't work as written - you'll need to use `:jidea-46` in place of `:latest` in the pull and run, so:

```
docker pull mrcide/daedalus.api:jidea-46
docker run -d --rm -p 8001:8001 --name daedalus-api mrcide/daedalus.api:jidea-46
curl -s http://localhost:8001 | jq
docker stop daedalus-api
```

Buildkite should report back on build, and this is configured: https://buildkite.com/mrc-ide/daedalus-dot-api/settings/repository (see "Update commit statuses").  This is not happening, but I hope that once we get things onto main it will start, otherwise let's investigate.  The webhooks are definitely making it.  You can see build history here https://buildkite.com/mrc-ide/daedalus-dot-api (once you have logged in, invite has gone to your college address)