### PR TITLE
jidea-72 Add sample results metadata

### DIFF
--- a/inst/json/metadata_0.1.0.json
+++ b/inst/json/metadata_0.1.0.json
@@ -43,5 +43,34 @@
         { "id": "high", "label": "High" }
       ]
     }
-  ]
+  ],
+  "results": {
+    "costs": [
+      { "id": "total", "label": "Total", "description": "Total cost to national economy" },
+      { "id": "gdp", "label": "GDP" },
+      { "id": "gdp_closures", "label": "Closures" },
+      { "id": "gdp_absences", "label": "Absences" },
+      { "id": "education", "label": "Education" },
+      { "id": "education_closures", "label": "Closures" },
+      { "id": "education_absences", "label": "Absences" },
+      { "id": "life_years", "label": "Life Years" },
+      { "id": "life_years_infants", "label": "Infants" },
+      { "id": "life_years_adolescents", "label": "Adolescents" },
+      { "id": "life_years_working_age", "label": "Working-age Adults" },
+      { "id": "life_years_retirement_age", "label": "Retirement-age Adults" }
+    ],
+    "capacities": [
+      { "id": "hospital_capacity", "label": "Hospital Capacity", "description": "Total hospital beds" },
+      { "id": "icu_capacity", "label": "ICU Capacity", "description": "ICU hospital beds" }
+    ],
+    "interventions": [
+      { "id": "school_closures", "label": "School closures" },
+      { "id": "business_closures", "label": "Business closures" }
+    ],
+    "time_series": [
+      { "id": "cases", "label": "Cases", "description": "Number of confirmed cases" },
+      { "id": "vacc", "label": "Vaccinated", "description": "Cumulative vaccinations" },
+      { "id": "hosp_occ", "label": "Hospital Occupancy", "description": "Number of hospitalised cases" }
+    ]
+  }
 }

--- a/inst/schema/metadata.json
+++ b/inst/schema/metadata.json
@@ -1,5 +1,17 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
+    "$defs": {
+        "info": {
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "label": { "type": "string" },
+                "description": { "type": ["string", "null"] }
+            },
+            "additionalProperties": false,
+            "required": ["id", "label"]
+        }
+    },
     "type": "object",
     "properties": {
       "modelVersion": {
@@ -37,8 +49,39 @@
           "additionalProperties": false,
           "required": ["id", "label", "parameterType", "defaultOption", "ordered", "options"]
         }
+      },
+      "results": {
+        "type": "object",
+        "properties": {
+          "costs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/info"
+            }
+          },
+          "capacities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/info"
+            }
+          },
+          "interventions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/info"
+            }
+          },
+          "time_series": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/info"
+            }
+          }
+        },
+        "additionalProperties": false,
+        "required": ["costs", "capacities", "interventions", "time_series"]
       }
     },
     "additionalProperties": false,
-    "required": ["modelVersion", "parameters"]
+    "required": ["modelVersion", "parameters", "results"]
 }

--- a/inst/schema/metadata.json
+++ b/inst/schema/metadata.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "$defs": {
-        "info": {
+        "displayInfo": {
             "type": "object",
             "properties": {
                 "id": { "type": "string" },
@@ -56,25 +56,25 @@
           "costs": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/info"
+              "$ref": "#/$defs/displayInfo"
             }
           },
           "capacities": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/info"
+              "$ref": "#/$defs/displayInfo"
             }
           },
           "interventions": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/info"
+              "$ref": "#/$defs/displayInfo"
             }
           },
           "time_series": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/info"
+              "$ref": "#/$defs/displayInfo"
             }
           }
         },


### PR DESCRIPTION
This branch adds metadata for model run results as discussed. 
I've added an 'info' schema with `id`, `label` and optional `description` properties. The metadata response now includes arrays of these for costs, capacities, interventions and time series. 
The metadata being returned for these is just a placeholder which matches the dummy results data. I've included descriptions for some things but not others. 

Arguably, the `parameters` could also include an `info` part with id, label and description - but since you can't 'inherit' a json schema, that would have to be nested in a property, which I don't think would be ideal.   

Feel free to come up with a better name than "info"! 