### PR TITLE
jidea-80 Add hospital capacity parameter

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,7 +1,7 @@
 linters: all_linters(
 	indentation_linter = NULL, # unstable as of lintr 3.1.0
 	extraction_operator_linter = NULL, # allow R6 syntax from {porcelain}
-	implicit_integer_linter = NULL # allow port notation without integer L
+	implicit_integer_linter = NULL
 	)
 exclusions: list(
 	"tests/testthat.R" = list(

--- a/.lintr
+++ b/.lintr
@@ -1,14 +1,12 @@
 linters: all_linters(
 	indentation_linter = NULL, # unstable as of lintr 3.1.0
 	extraction_operator_linter = NULL # allow R6 syntax from {porcelain}
+	implicit_integer_linter = Inf # allow port notation without integer L
 	)
 exclusions: list(
 	"tests/testthat.R" = list(
 		unused_import_linter = Inf,
 		undesirable_function_linter = Inf # allow library() calls
-	),
-	"tests/testthat/test-main.R" = list(
-		implicit_integer_linter = Inf # allow port notation without integer L
 	),
 	"tests/testthat/test-endpoints.R" = list(
 	    absolute_path_linter = Inf, # spurious path errors for routes

--- a/.lintr
+++ b/.lintr
@@ -1,7 +1,7 @@
 linters: all_linters(
 	indentation_linter = NULL, # unstable as of lintr 3.1.0
-	extraction_operator_linter = NULL # allow R6 syntax from {porcelain}
-	implicit_integer_linter = Inf # allow port notation without integer L
+	extraction_operator_linter = NULL, # allow R6 syntax from {porcelain}
+	implicit_integer_linter = NULL # allow port notation without integer L
 	)
 exclusions: list(
 	"tests/testthat.R" = list(

--- a/R/api.R
+++ b/R/api.R
@@ -47,7 +47,7 @@ metadata <- function() {
     list(id = scalar(id), label = scalar(label))
   }
 
-  param_ids <- lapply(response$parameters, function(param){
+  param_ids <- lapply(response$parameters, function(param) {
     param$id
   })
 
@@ -79,10 +79,12 @@ metadata <- function() {
   hospital_capacity_idx <- match("hospital_capacity", param_ids)
   step <- response$parameters[[hospital_capacity_idx]]$step
   # setNames to get json object not array
-  hospital_capacities <- lapply(setNames(country_names, country_names), function(country) {
-    demography <- daedalus::country_data[[country]]$demography
-    population <- sum(unlist(demography))
-    get_hospital_capacity_for_population(population, step)
+  hospital_capacities <- lapply(
+    setNames(country_names, country_names),
+    function(country) {
+      demography <- daedalus::country_data[[country]]$demography
+      population <- sum(unlist(demography))
+      get_hospital_capacity_for_pop(population, step)
   })
   response$parameters[[hospital_capacity_idx]]$updateNumericFrom <- list(
     parameterId = "country",

--- a/R/api.R
+++ b/R/api.R
@@ -41,7 +41,6 @@ metadata <- function() {
   metadata_version <- "0.1.0"
   metadata_file <- sprintf("metadata_%s.json", metadata_version)
   response <- read_local_json(metadata_file)
-
   response$modelVersion <- model_version
   # Helper for the options which don't come from the json
   get_option <- function(id, label) {
@@ -77,9 +76,9 @@ metadata <- function() {
   pathogen_idx <- match("pathogen", param_ids)
   response$parameters[[pathogen_idx]]$options <- pathogen_options
 
-  # setNames to get json object not array
   hospital_capacity_idx <- match("hospital_capacity", param_ids)
   step <- response$parameters[[hospital_capacity_idx]]$step
+  # setNames to get json object not array
   hospital_capacities <- lapply(setNames(country_names, country_names), function(country) {
     demography <- daedalus::country_data[[country]]$demography
     population <- sum(unlist(demography))

--- a/R/api.R
+++ b/R/api.R
@@ -41,20 +41,29 @@ metadata <- function() {
   metadata_version <- "0.1.0"
   metadata_file <- sprintf("metadata_%s.json", metadata_version)
   response <- read_local_json(metadata_file)
+
   response$modelVersion <- model_version
   # Helper for the options which don't come from the json
   get_option <- function(id, label) {
     list(id = scalar(id), label = scalar(label))
   }
+
+  param_ids <- lapply(response$parameters, function(param){
+    param$id
+  })
+
   # Set available countries from daedalus package
   # JIDEA-62: use the right version of daedalus/model
   # we will get ISO ids from daedalus when available
-  country_options <- lapply(daedalus::country_names, function(country) {
+  country_names <- daedalus::country_names
+
+  country_options <- lapply(country_names, function(country) {
     country_string <- as.character(country)
     get_option(country_string, country_string)
   })
-  country_idx <- match("country", response$parameters$id)
-  response$parameters$options[[country_idx]] <- country_options
+  country_idx <- match("country", param_ids)
+  response$parameters[[country_idx]]$options <- country_options
+
   # JIDEA-61: get pathogen information from daedalus, when available
   pathogen_options <- list(
     get_option("sars-cov-1", "SARS-CoV-1"),
@@ -65,9 +74,23 @@ metadata <- function() {
     get_option("influenza-1957", "Influenza 1957"),
     get_option("influenza-1918", "Influenza 1918 (Spanish flu)")
   )
-  pathogen_idx <- match("pathogen", response$parameters$id)
-  response$parameters$options[[pathogen_idx]] <- pathogen_options
-  response
+  pathogen_idx <- match("pathogen", param_ids)
+  response$parameters[[pathogen_idx]]$options <- pathogen_options
+
+  # setNames to get json object not array
+  hospital_capacity_idx <- match("hospital_capacity", param_ids)
+  step <- response$parameters[[hospital_capacity_idx]]$step
+  hospital_capacities <- lapply(setNames(country_names, country_names), function(country) {
+    demography <- daedalus::country_data[[country]]$demography
+    population <- sum(unlist(demography))
+    get_hospital_capacity_for_population(population, step)
+  })
+  response$parameters[[hospital_capacity_idx]]$updateNumericFrom <- list(
+    parameterId = "country",
+    values = hospital_capacities
+  )
+
+  json_verbatim(response)
 }
 
 #' @porcelain

--- a/R/api.R
+++ b/R/api.R
@@ -57,8 +57,7 @@ metadata <- function() {
   country_names <- daedalus::country_names
 
   country_options <- lapply(country_names, function(country) {
-    country_string <- as.character(country)
-    get_option(country_string, country_string)
+    get_option(country, country)
   })
   country_idx <- match("country", param_ids)
   response$parameters[[country_idx]]$options <- country_options
@@ -83,7 +82,7 @@ metadata <- function() {
     setNames(country_names, country_names),
     function(country) {
       demography <- daedalus::country_data[[country]]$demography
-      population <- sum(unlist(demography))
+      population <- sum(demography)
       get_hospital_capacity_for_pop(population, step)
   })
   response$parameters[[hospital_capacity_idx]]$updateNumericFrom <- list(

--- a/R/util.R
+++ b/R/util.R
@@ -17,7 +17,7 @@ system_file <- function(...) {
 }
 
 read_local_json <- function(filename) {
-  jsonlite::fromJSON(system_file("json", filename), simplifyVector=FALSE)
+  jsonlite::fromJSON(system_file("json", filename), simplifyVector = FALSE)
 }
 
 # (Probably) temporary method to return verbatim sample json
@@ -26,18 +26,19 @@ json_verbatim <- function(json) {
   jsonlite::toJSON(json, auto_unbox = TRUE, null = "null")
 }
 
-get_hospital_capacity_for_population <- function(population, step) {
-  # This is very likely to change but for now we set hospital capacity values for a country as:
+get_hospital_capacity_for_pop <- function(population, step) {
+  # This is very likely to change but for now we set hospital capacity values
+  # for a country as:
   # min: 30 per 100K population
   # default: 45 per 100K population
   # max: 130 per 100K population
-  value_per_100K_pop_as_absolute <- function(value, population, step) {
+  value_per_100k_pop_as_absolute <- function(value, population, step) {
     unrounded <- (population / 100000) * value
-    round(unrounded/step) * step
+    round(unrounded / step) * step
   }
   list(
-    min = value_per_100K_pop_as_absolute(30, population, step),
-    default = value_per_100K_pop_as_absolute(45, population, step),
-    max = value_per_100K_pop_as_absolute(130, population, step)
+    min = value_per_100k_pop_as_absolute(30, population, step),
+    default = value_per_100k_pop_as_absolute(45, population, step),
+    max = value_per_100k_pop_as_absolute(130, population, step)
   )
 }

--- a/R/util.R
+++ b/R/util.R
@@ -17,11 +17,27 @@ system_file <- function(...) {
 }
 
 read_local_json <- function(filename) {
-  jsonlite::fromJSON(system_file("json", filename))
+  jsonlite::fromJSON(system_file("json", filename), simplifyVector=FALSE)
 }
 
 # (Probably) temporary method to return verbatim sample json
 # - return nulls as nulls and scalars as scalars!
 json_verbatim <- function(json) {
   jsonlite::toJSON(json, auto_unbox = TRUE, null = "null")
+}
+
+get_hospital_capacity_for_population <- function(population, step) {
+  # This is very likely to change but for now we set hospital capacity values for a country as:
+  # min: 30 per 100K population
+  # default: 45 per 100K population
+  # max: 130 per 100K population
+  value_per_100K_pop_as_absolute <- function(value, population, step) {
+    unrounded <- (population / 100000) * value
+    round(unrounded/step) * step
+  }
+  list(
+    min = value_per_100K_pop_as_absolute(30, population, step),
+    default = value_per_100K_pop_as_absolute(45, population, step),
+    max = value_per_100K_pop_as_absolute(130, population, step)
+  )
 }

--- a/inst/json/metadata_0.1.0.json
+++ b/inst/json/metadata_0.1.0.json
@@ -42,6 +42,16 @@
         { "id": "medium", "label": "Medium" },
         { "id": "high", "label": "High" }
       ]
+    },
+    {
+      "id": "hospital_capacity",
+      "label": "Hospital capacity",
+      "parameterType": "numeric",
+      "step": 100,
+      "updateNumericFrom": {
+        "parameterId": "country",
+        "values": null
+      }
     }
   ],
   "results": {

--- a/inst/json/metadata_0.1.0.json
+++ b/inst/json/metadata_0.1.0.json
@@ -5,6 +5,7 @@
       "id": "country",
       "label": "Country",
       "parameterType": "globeSelect",
+      "defaultOption": "Thailand",
       "ordered": false,
       "options": null
     },

--- a/inst/json/metadata_0.1.0.json
+++ b/inst/json/metadata_0.1.0.json
@@ -5,7 +5,6 @@
       "id": "country",
       "label": "Country",
       "parameterType": "globeSelect",
-      "defaultOption": null,
       "ordered": false,
       "options": null
     },
@@ -13,7 +12,6 @@
       "id": "pathogen",
       "label": "Disease",
       "parameterType": "select",
-      "defaultOption": null,
       "ordered": false,
       "options": null
     },
@@ -47,11 +45,9 @@
       "id": "hospital_capacity",
       "label": "Hospital capacity",
       "parameterType": "numeric",
+      "ordered": false,
       "step": 100,
-      "updateNumericFrom": {
-        "parameterId": "country",
-        "values": null
-      }
+      "updateNumericFrom": null
     }
   ],
   "results": {

--- a/inst/schema/metadata.json
+++ b/inst/schema/metadata.json
@@ -27,7 +27,7 @@
             "label": { "type": "string" },
             "parameterType": {
               "type": "string",
-              "enum": ["select", "globeSelect"]
+              "enum": ["select", "globeSelect", "numeric"]
             },
             "defaultOption": {
               "type": ["string", "null"]
@@ -43,11 +43,33 @@
                 },
                 "additionalProperties": false,
                 "required": ["id", "label"]
+              },
+              "step": { "type": "number" },
+              "updateNumericFrom": {
+                "type": "object",
+                "properties": {
+                  "parameterId":  { "type": "string" },
+                  "values": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object",
+                      "properties": {
+                        "min": { "type": "number" },
+                        "default": { "type": "number" },
+                        "max": { "type": "number" }
+                      },
+                      "additionalProperties": false,
+                      "required": ["min", "default", "max"]
+                    }
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["parameterId", "values"]
               }
             }
           },
           "additionalProperties": false,
-          "required": ["id", "label", "parameterType", "defaultOption", "ordered", "options"]
+          "required": ["id", "label", "parameterType"]
         }
       },
       "results": {

--- a/inst/schema/metadata.json
+++ b/inst/schema/metadata.json
@@ -30,46 +30,53 @@
               "enum": ["select", "globeSelect", "numeric"]
             },
             "defaultOption": {
-              "type": ["string", "null"]
+              "type": "string"
             },
             "ordered": { "type": "boolean" },
             "options": {
               "type": "array",
               "items": {
                 "type": "object",
-                "properties":{
-                  "id": { "type": "string" },
-                  "label": { "type": "string" }
-                },
-                "additionalProperties": false,
-                "required": ["id", "label"]
-              },
-              "step": { "type": "number" },
-              "updateNumericFrom": {
-                "type": "object",
                 "properties": {
-                  "parameterId":  { "type": "string" },
-                  "values": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": "object",
-                      "properties": {
-                        "min": { "type": "number" },
-                        "default": { "type": "number" },
-                        "max": { "type": "number" }
-                      },
-                      "additionalProperties": false,
-                      "required": ["min", "default", "max"]
-                    }
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
                   }
                 },
                 "additionalProperties": false,
-                "required": ["parameterId", "values"]
+                "required": [
+                  "id",
+                  "label"
+                ]
               }
+            },
+            "step": { "type": "number" },
+            "updateNumericFrom": {
+              "type": "object",
+              "properties": {
+                "parameterId":  { "type": "string" },
+                "values": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "min": { "type": "number" },
+                      "default": { "type": "number" },
+                      "max": { "type": "number" }
+                    },
+                    "additionalProperties": false,
+                    "required": ["min", "default", "max"]
+                  }
+                }
+              },
+              "additionalProperties": false,
+              "required": ["parameterId", "values"]
             }
           },
           "additionalProperties": false,
-          "required": ["id", "label", "parameterType"]
+          "required": ["id", "label", "parameterType", "ordered"]
         }
       },
       "results": {

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -35,7 +35,7 @@ test_that("Can get metadata", {
   )
   expect_true(res$validated)
 
-  res <- jsonlite::fromJSON(res$body, simplifyVector=FALSE)
+  res <- jsonlite::fromJSON(res$body, simplifyVector = FALSE)
 
   params <- res$data$parameters
   expected_parameters <- c(
@@ -69,10 +69,9 @@ test_that("Can get metadata", {
     daedalus_countries
   )
   expect_identical(params[[country_idx]]$defaultOption, "Thailand")
-  # expect hospital_capacity updateNumericFrom keys to match countries from daedalus
   hosp_cap_idx <- match("hospital_capacity", expected_parameters)
   update_values <- res$data$parameters[[hosp_cap_idx]]$updateNumericFrom$values
-  expect_identical(names(update_values), daedalus_countries)
+  expect_named(update_values, daedalus_countries)
   for (country in daedalus_countries) {
     values <- update_values[[country]]
     expect_identical(values$min %% 100, 0)

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -1,6 +1,6 @@
 test_that("can get hospital capacity for population", {
   result <- get_hospital_capacity_for_pop(1263182, 10)
-  expect_identical(result$min, 380)#
+  expect_identical(result$min, 380)
   expect_identical(result$default, 570)
   expect_identical(result$max, 1640)
 })

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -1,5 +1,5 @@
 test_that("can get hospital capacity for population", {
-  result <- get_hospital_capacity_for_population(1263182, 10)
+  result <- get_hospital_capacity_for_pop(1263182, 10)
   expect_identical(result$min, 380)#
   expect_identical(result$default, 570)
   expect_identical(result$max, 1640)

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -1,0 +1,6 @@
+test_that("can get hospital capacity for population", {
+  result <- get_hospital_capacity_for_population(1263182, 10)
+  expect_identical(result$min, 380)#
+  expect_identical(result$default, 570)
+  expect_identical(result$max, 1640)
+})


### PR DESCRIPTION
This branch adds the Hospital Capacity parameter to the metadata returned by the api. 

This is a new parameter type - numeric -  and also has "update from" config associated with it, in that when the user changes the selected country, the default Hospital Capacity should update to a value appropriate to the new country. There are also min and max values assocaited with each country - the front end should not accept user entered values outside this range. 

These values are currently being calculated using a flat rate per 100k population (as suggested by Patrick). Population is calculated by summing the country demography values from daedalus package. The capacity values for each country are then calcualted as: 30 per 100k for minimum, 45 for default, 130 for maxumum. However we expect these values to be refined by country group later - to be discussed at the next meeting - so this approach can be considered a placeholder for now. 

The JSON schema has been updated to support numeric parameters. The props which are associated only with select parameters or numeric parameters are not required, but can be undefined when not relevant. 

I've also set the default country to Thailand - as agreed at the last meeting, we will set this as the default for the initial workshop. 

I've changed the json read method to use `simplifyVector=FALSE` as I was finding it too difficult to navigate and modify the metadata as a dataframe rather than a nested list!