### PR TITLE
Jidea-114 Hospital capacities from package

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -86,9 +86,8 @@ metadata <- function() {
   hospital_capacities <- lapply(
     setNames(country_names, country_names),
     function(country) {
-      demography <- daedalus::country_data[[country]]$demography
-      population <- sum(demography)
-      get_hospital_capacity_for_pop(population, step)
+      default <- daedalus::daedalus_country(country)$hospital_capacity
+      get_hospital_capacity_range(default, step)
   })
   response$parameters[[hospital_capacity_idx]]$updateNumericFrom <- list(
     parameterId = "country",

--- a/R/util.R
+++ b/R/util.R
@@ -37,7 +37,7 @@ get_hospital_capacity_range <- function(default_capacity, step) {
   list(
     min = round_value(default_capacity * 0.9, step),
     default = round_value(default_capacity, step),
-    max = roun_value(default_capacity * 1.3, step)
+    max = round_value(default_capacity * 1.3, step)
   )
 }
 

--- a/R/util.R
+++ b/R/util.R
@@ -32,7 +32,7 @@ get_hospital_capacity_range <- function(default_capacity, step) {
   # min: 90% of default
   # max: 130% of default
   round_value <- function(value, step) {
-    round(value/ step) * step
+    round(value / step) * step
   }
   list(
     min = round_value(default_capacity * 0.9, step),

--- a/R/util.R
+++ b/R/util.R
@@ -24,20 +24,20 @@ to_json <- function(data, auto_unbox = FALSE, ...) {
   jsonlite::toJSON(data, auto_unbox = auto_unbox, null = "null", ...)
 }
 
-get_hospital_capacity_for_pop <- function(population, step) {
-  # This is very likely to change but for now we set hospital capacity values
-  # for a country as:
-  # min: 30 per 100K population
-  # default: 45 per 100K population
-  # max: 130 per 100K population
-  value_per_100k_pop_as_absolute <- function(value, population, step) {
-    unrounded <- (population / 100000) * value
-    round(unrounded / step) * step
+get_hospital_capacity_range <- function(default_capacity, step) {
+  # Given a default hospital capacity from daedalus return a range from
+  # which the user can choose, with min, default and max, all rounded to
+  # the step value.
+  # Range values are:
+  # min: 90% of default
+  # max: 130% of default
+  round_value <- function(value, step) {
+    round(value/ step) * step
   }
   list(
-    min = value_per_100k_pop_as_absolute(30, population, step),
-    default = value_per_100k_pop_as_absolute(45, population, step),
-    max = value_per_100k_pop_as_absolute(130, population, step)
+    min = round_value(default_capacity * 0.9, step),
+    default = round_value(default_capacity, step),
+    max = roun_value(default_capacity * 1.3, step)
   )
 }
 

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -1,8 +1,8 @@
-test_that("can get hospital capacity for population", {
-  result <- get_hospital_capacity_for_pop(1263182, 10)
-  expect_identical(result$min, 380)
-  expect_identical(result$default, 570)
-  expect_identical(result$max, 1640)
+test_that("can get hospital capacity range", {
+  result <- get_hospital_capacity_for_pop(4513, 100)
+  expect_identical(result$min, 4100)
+  expect_identical(result$default, 4500)
+  expect_identical(result$max, 5900)
 })
 
 test_that("can validate valid parameters", {

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -1,5 +1,5 @@
 test_that("can get hospital capacity range", {
-  result <- get_hospital_capacity_for_pop(4513, 100)
+  result <- get_hospital_capacity_range(4513, 100)
   expect_identical(result$min, 4100)
   expect_identical(result$default, 4500)
   expect_identical(result$max, 5900)


### PR DESCRIPTION
This branch fetches country hospital capacities from the package, rather than estimating from population. The capacity range allowed by web app input is returned as min: 90% of default, max: 130% of default. All values are rounded to the step defined in the metadata (currently 100).