### PR TITLE
jidea-112 Take hospital capacity in results from parameter value

### DIFF
--- a/R/model_run.R
+++ b/R/model_run.R
@@ -5,12 +5,13 @@ model_run <- function(parameters, model_version) {
   # TODO: include vaccine in params to daedalus
   vaccine <- parameters$vaccine
   hospital_capacity <- parameters$hospital_capacity
+  hospital_capacity_num <- as.numeric(hospital_capacity)
 
   model_results <- daedalus::daedalus(
     country,
     pathogen,
     response_strategy = response,
-    response_threshold = as.numeric(hospital_capacity)
+    response_threshold = hospital_capacity_num
   )
   time_series <- dplyr::group_by(model_results$model_data, time, compartment)
   time_series <- dplyr::summarise(time_series, value = sum(value))
@@ -26,7 +27,7 @@ model_run <- function(parameters, model_version) {
   raw_costs <- daedalus::get_costs(model_results)
   costs <- get_nested_costs(raw_costs)
 
-  # read sample data, replace costs, time series and parameters with real values
+  # read sample data, replace with real values where available
   results <- read_local_json("sample_scenario_results_response.json")
   results$parameters <- list(
     country = country,
@@ -37,5 +38,11 @@ model_run <- function(parameters, model_version) {
   )
   results$costs <- costs
   results$time_series <- time_series
+  results$capacities <- list(
+    list(
+      id = "hospital_capacity",
+      value = hospital_capacity_num
+    )
+  )
   results
 }

--- a/inst/json/metadata_0.1.0.json
+++ b/inst/json/metadata_0.1.0.json
@@ -67,8 +67,11 @@
       { "id": "life_years_retirement_age", "label": "Retirement-age adults" }
     ],
     "capacities": [
-      { "id": "hospital_capacity", "label": "Hospital capacity", "description": "Total hospital beds" },
-      { "id": "icu_capacity", "label": "ICU capacity", "description": "ICU hospital beds" }
+      {
+        "id": "hospital_capacity",
+        "label": "Hospital surge capacity",
+        "description": "Number of hospital beds available nationally for pandemic patients"
+      }
     ],
     "interventions": [
       { "id": "school_closures", "label": "School closures" },

--- a/inst/json/sample_scenario_results_response.json
+++ b/inst/json/sample_scenario_results_response.json
@@ -2,16 +2,7 @@
   "runId": null,
   "parameters": null,
   "costs": null,
-  "capacities": [
-    {
-      "id": "hospital_capacity",
-      "value": 40000
-    },
-    {
-      "id": "icu_capacity",
-      "value": 5000
-    }
-  ],
+  "capacities": null,
   "interventions": [
     {
       "id": "school_closures",

--- a/tests/testthat/test_model_run.R
+++ b/tests/testthat/test_model_run.R
@@ -42,4 +42,7 @@ test_that("can run model and return results", {
   expect_identical(res$time_series$dead, c(15L, 35L))
   expect_identical(res$parameters, parameters)
   expect_nested_mock_costs(res$costs)
+  expect_length(res$capacities, 1L)
+  expect_identical(res$capacities[[1]]$id, "hospital_capacity")
+  expect_identical(res$capacities[[1]]$value, 4500)
 })


### PR DESCRIPTION
This branch replaces the dummy `capacities` value in the model results with a single capacity, `hospital_capacity` which is just taken from the corresponding parameter value. 

The icu capacity has been removed from the  metadata, as it is not available in the model currently. 

Once this branch, and https://github.com/jameel-institute/daedalus.api/pull/16 are merged, we'll be able to remove the dummy sample results file entirely as all results will now be coming from daedalus.  