### PR TITLE
JIDEA-129: Upgrade R in container

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus.api
 Title: Serve the 'daedalus' model via an API
-Version: 0.0.1
+Version: 0.0.2
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,4 @@
-# TODO: update version
-FROM rocker/r-ver:4.1
+FROM rocker/r-ver:4.4
 
 RUN apt-get update &&  apt-get install -y --no-install-recommends \
         libcurl4-openssl-dev \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ COPY docker/Rprofile.site /usr/local/lib/R/etc/Rprofile.site
 RUN install2.r --error \
         --repos=https://mrc-ide.r-universe.dev \
         --repos=https://jameel-institute.r-universe.dev \
-        --repos=https://packagemanager.posit.co/all/__linux__/focal/latest \
+        --repos=https://packagemanager.posit.co/all/__linux__/jammy/latest \
         daedalus \
         docopt \
         jsonlite \

--- a/docker/Rprofile.site
+++ b/docker/Rprofile.site
@@ -1,4 +1,4 @@
-options(repos = c(CRAN = 'https://packagemanager.posit.co/all/__linux__/focal/latest'), download.file.method = 'libcurl')
+options(repos = c(CRAN = 'https://packagemanager.posit.co/all/__linux__/jammy/latest'), download.file.method = 'libcurl')
 options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(),
                  paste(getRversion(), R.version$platform,
                        R.version$arch, R.version$os)))


### PR DESCRIPTION
See https://github.com/jameel-institute/daedalus.api/pull/16 for context.

We have been using 4.1 as the R version in the base image due to a incompatible library version of openssl shipped from the RSPM and the versions included in the image.  This seems to be resolved now and using openssl on a recent 4.4 container works fine.

This PR will have run the connection test, so if there are further breakages, we probably need to move them into integration tests here too.  However, I can't replicate the issue we saw on Pratik's machine anywhere so think a pull was probably enough to fix