### PR TITLE
jidea-108 add vaccine_investment param to daedalus call

### DIFF
--- a/R/model_run.R
+++ b/R/model_run.R
@@ -2,7 +2,6 @@ model_run <- function(parameters, model_version) {
   country <- parameters$country
   pathogen <- parameters$pathogen
   response <- parameters$response
-  # TODO: include vaccine in params to daedalus
   vaccine <- parameters$vaccine
   hospital_capacity <- parameters$hospital_capacity
   hospital_capacity_num <- as.numeric(hospital_capacity)
@@ -11,7 +10,8 @@ model_run <- function(parameters, model_version) {
     country,
     pathogen,
     response_strategy = response,
-    response_threshold = hospital_capacity_num
+    response_threshold = hospital_capacity_num,
+    vaccine_investment = vaccine
   )
   time_series <- dplyr::group_by(model_results$model_data, time, compartment)
   time_series <- dplyr::summarise(time_series, value = sum(value))

--- a/tests/testthat/test_model_run.R
+++ b/tests/testthat/test_model_run.R
@@ -31,7 +31,8 @@ test_that("can run model and return results", {
     list("Canada",
          "influenza_1918",
          response_strategy = "elimination",
-         response_threshold = 4500
+         response_threshold = 4500,
+         vaccine_investment = "high"
     )
   )
 


### PR DESCRIPTION
This branch passes the `vaccine` parameter from the run request to the daedalus package, in its `vaccine_investment` parameter. 

To test:
1. `./docker/run_containers`
2. Run the model -vary the vaccine parameter (can be: none/low/medium/high):
```
curl -H "Content-Type: application/json" -d '{"modelVersion": "0.0.1", "parameters": {"country": "Canada", "pathogen": "sars_cov_1", "response": "none", "vaccine": "low", "hospital_capacity": "10500"}}' http://localhost:8001/scenario/run
```
3. Get results: should see varying data and costs for different vaccine values:
```
curl http://localhost:8001/scenario/results/[RUN_ID]
```