### PR TITLE
jidea-130 Replace Community Infections time series with Prevalence

### DIFF
--- a/R/model_run.R
+++ b/R/model_run.R
@@ -19,7 +19,11 @@ model_run <- function(parameters, model_version) {
     time_series,
     id_cols = "time", values_from = "value", names_from = "compartment"
   )
-  time_series$prevalence <- time_series$infect_asymp + time_series$infect_symp + time_series$hospitalised
+  time_series$prevalence <-
+    time_series$infect_asymp +
+    time_series$infect_symp +
+    time_series$hospitalised
+
   time_series <- time_series[, c("prevalence",
                                 "hospitalised",
                                 "dead")]

--- a/R/model_run.R
+++ b/R/model_run.R
@@ -19,8 +19,8 @@ model_run <- function(parameters, model_version) {
     time_series,
     id_cols = "time", values_from = "value", names_from = "compartment"
   )
-  time_series$infect <- time_series$infect_asymp + time_series$infect_symp
-  time_series <- time_series[, c("infect",
+  time_series$prevalence <- time_series$infect_asymp + time_series$infect_symp + time_series$hospitalised
+  time_series <- time_series[, c("prevalence",
                                 "hospitalised",
                                 "dead")]
 

--- a/inst/json/metadata_0.1.0.json
+++ b/inst/json/metadata_0.1.0.json
@@ -81,7 +81,10 @@
       }
     ],
     "time_series": [
-      { "id": "infect", "label": "Community infections", "description": "Infections not requiring hospitalisation" },
+      {
+        "id": "prevalence",
+        "label": "Prevalence",
+        "description": "Number of infectious individuals, comprising both symptomatic and asymptomatic infections, including those in need of hospitalisation." },
       { "id": "hospitalised", "label": "Hospital demand", "description": "Infections requiring hospitalisation" },
       { "id": "dead", "label": "Dead", "description": "Cumulative deaths" }
     ]

--- a/tests/testthat/test_model_run.R
+++ b/tests/testthat/test_model_run.R
@@ -42,10 +42,10 @@ test_that("can run model and return results", {
     "interventions",
     "capacities"
   ))
-  expect_named(res$time_series, c("infect",
+  expect_named(res$time_series, c("prevalence",
                                   "hospitalised",
                                   "dead"))
-  expect_identical(res$time_series$infect, c(16L, 56L))
+  expect_identical(res$time_series$prevalence, c(27L, 87L))
   expect_identical(res$time_series$hospitalised, c(11L, 31L))
   expect_identical(res$time_series$dead, c(15L, 35L))
   expect_identical(res$parameters, parameters)


### PR DESCRIPTION
This branch replaces the Community Infections (`infect`) time series with Prevalence (`prevalence`), which includes hospitalisations as well as symptomatic and asymptomatic community cases. 

To test manually:
1. `./docker/run_containers`
2. Request a run:
```
curl -H "Content-Type: application/json" -d '{"modelVersion": "0.0.1", "parameters": {"country": "Canada", "pathogen": "sars_cov_1", "response": "none", "vaccine": "low", "hospital_capacity": "10500"}}' http://localhost:8001/scenario/run
```
3. Get results. prevalence should be included in the time series result. 
```
curl http://localhost:8001/scenario/results/[RUN_ID]
```

Tagging @david-mears-2 as there be some knock on effect for the web app if it includes hardcoded reference to the `infect` time series. 