### PR TITLE
Jidea 82 Parameter help text

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ License: MIT + file LICENSE
 URL: https://github.com/jameel-institute/daedalus.api
 BugReports: https://github.com/jameel-institute/daedalus.api/issues
 Imports: 
-    daedalus (>= 0.0.15),
+    daedalus (>= 0.0.17),
     docopt,
     dplyr,
     jsonlite,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus.api
 Title: Serve the 'daedalus' model via an API
-Version: 0.0.3
+Version: 0.0.4
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ License: MIT + file LICENSE
 URL: https://github.com/jameel-institute/daedalus.api
 BugReports: https://github.com/jameel-institute/daedalus.api/issues
 Imports: 
-    daedalus (>= 0.0.8),
+    daedalus (>= 0.0.15),
     docopt,
     dplyr,
     jsonlite,
@@ -22,6 +22,7 @@ Imports:
     R6,
     redux,
     rrq,
+    stringr,
     tidyr
 Suggests: 
     httr,

--- a/R/api.R
+++ b/R/api.R
@@ -99,7 +99,8 @@ metadata <- function() {
   response$parameters[[vaccine_idx]]$options <- lapply(
     response$parameters[[vaccine_idx]]$options,
     function(vaccine_option) {
-      vaccine_option$description <- get_vaccine_option_description(vaccine_option$id)
+      vaccine_option$description <-
+        get_vaccine_option_description(vaccine_option$id)
       vaccine_option
     }
   )

--- a/R/api.R
+++ b/R/api.R
@@ -89,9 +89,19 @@ metadata <- function() {
       default <- daedalus::daedalus_country(country)$hospital_capacity
       get_hospital_capacity_range(default, step)
   })
+
   response$parameters[[hospital_capacity_idx]]$updateNumericFrom <- list(
     parameterId = "country",
     values = hospital_capacities
+  )
+
+  vaccine_idx <- match("vaccine", param_ids)
+  response$parameters[[vaccine_idx]]$options <- lapply(
+    response$parameters[[vaccine_idx]]$options,
+    function(vaccine_option) {
+      vaccine_option$description <- get_vaccine_option_description(vaccine_option$id)
+      vaccine_option
+    }
   )
 
   to_json(response, auto_unbox = TRUE)

--- a/R/model_run.R
+++ b/R/model_run.R
@@ -34,10 +34,8 @@ model_run <- function(parameters, model_version) {
   interventions <- list()
   if (response != "none") {
     closure_info <- model_results$response_data$closure_info
-    level <- model_results$response_data$implementation_level
     closure <- list(
       id = "response",
-      level = level,
       start = closure_info$closure_time_start,
       end = closure_info$closure_time_end
     )

--- a/R/util.R
+++ b/R/util.R
@@ -42,7 +42,7 @@ get_hospital_capacity_range <- function(default_capacity, step) {
 }
 
 get_vaccine_option_description <- function(vaccine_option) {
-  # get vaccination data from the package for a given global vaccine 
+  # get vaccination data from the package for a given global vaccine
   # investment scenario, and generate description (help text) from that
   vax_data <- daedalus::vaccination_scenario_data[[vaccine_option]]
   stringr::str_glue(

--- a/R/util.R
+++ b/R/util.R
@@ -42,14 +42,15 @@ get_hospital_capacity_range <- function(default_capacity, step) {
 }
 
 get_vaccine_option_description <- function(vaccine_option) {
-  # get vaccination data from the package for a given global vaccine investment scenario, and
-  # generate description (help text) from that
+  # get vaccination data from the package for a given global vaccine 
+  # investment scenario, and generate description (help text) from that
   vax_data <- daedalus::vaccination_scenario_data[[vaccine_option]]
   stringr::str_glue(
     "An investment level corresponding to: ",
     "vaccine rollout commencing {start} days after the outbreak starts, ",
     "a vaccine administration rate of {rate}% of population per day, ",
-    "and an upper limit of vaccine coverage of {coverage}% of the general population",
+    "and an upper limit of vaccine coverage of {coverage}% of the ",
+    "general population",
     start = vax_data$vax_start_time,
     rate = signif(vax_data$nu, 2),
     coverage = vax_data$vax_uptake_limit

--- a/R/util.R
+++ b/R/util.R
@@ -41,6 +41,24 @@ get_hospital_capacity_range <- function(default_capacity, step) {
   )
 }
 
+get_vaccine_option_description <- function(vaccine_option) {
+  # get vaccination data from the package for a given global vaccine investment scenario, and
+  # generate description (help text) from that
+  vax_data <- daedalus::vaccination_scenario_data[[vaccine_option]]
+  res <- stringr::str_glue(
+    "An investment level corresponding to: ",
+    "vaccine rollout commencing {start} days after the outbreak starts, ",
+    "a vaccine administration rate of {rate}% of population per day, ",
+    "and an upper limit of vaccine coverage of {coverage}% of the general population",
+    start = vax_data$vax_start_time,
+    rate = signif(vax_data$nu, 2),
+    coverage = vax_data$vax_uptake_limit
+  )
+  print("GLUED")
+  print(res)
+  res
+}
+
 validate_parameters <- function(parameters, metadata) {
   # Expect parameters in model run request to include all and only values
   # specified in metadata

--- a/R/util.R
+++ b/R/util.R
@@ -45,7 +45,7 @@ get_vaccine_option_description <- function(vaccine_option) {
   # get vaccination data from the package for a given global vaccine investment scenario, and
   # generate description (help text) from that
   vax_data <- daedalus::vaccination_scenario_data[[vaccine_option]]
-  res <- stringr::str_glue(
+  stringr::str_glue(
     "An investment level corresponding to: ",
     "vaccine rollout commencing {start} days after the outbreak starts, ",
     "a vaccine administration rate of {rate}% of population per day, ",
@@ -54,9 +54,6 @@ get_vaccine_option_description <- function(vaccine_option) {
     rate = signif(vax_data$nu, 2),
     coverage = vax_data$vax_uptake_limit
   )
-  print("GLUED")
-  print(res)
-  res
 }
 
 validate_parameters <- function(parameters, metadata) {

--- a/inst/json/metadata_0.1.0.json
+++ b/inst/json/metadata_0.1.0.json
@@ -4,7 +4,7 @@
     {
       "id": "country",
       "label": "Country",
-      "description": "Select a country to set model parameters for country-specific demographic, mixing and economic data.",
+      "description": "Select a country to set model parameters for country-specific demographic, mixing and economic data",
       "parameterType": "globeSelect",
       "defaultOption": "United Kingdom",
       "ordered": false,
@@ -13,7 +13,7 @@
     {
       "id": "pathogen",
       "label": "Disease",
-      "description": "Select a disease to set model parameters for transmissibility, delays, and severity based on known characteristics of that historical epidemic or epidemic wave.",
+      "description": "Select a disease to set model parameters for transmissibility, delays, and severity based on known characteristics of that historical epidemic or epidemic wave",
       "parameterType": "select",
       "ordered": false,
       "options": null
@@ -50,6 +50,7 @@
     {
       "id": "vaccine",
       "label": "Global vaccine investment",
+      "description": "Select a level of advance global vaccine investment, which determines vaccine rollout start date, administration rate and coverage during the pandemic",
       "parameterType": "select",
       "defaultOption": "none",
       "ordered": true,
@@ -63,6 +64,7 @@
     {
       "id": "hospital_capacity",
       "label": "Hospital surge capacity",
+      "description": "Number of hospital beds available nationally for pandemic patients",
       "parameterType": "numeric",
       "ordered": false,
       "step": 100,

--- a/inst/json/metadata_0.1.0.json
+++ b/inst/json/metadata_0.1.0.json
@@ -4,6 +4,7 @@
     {
       "id": "country",
       "label": "Country",
+      "description": "Select a country to set model parameters for country-specific demographic, mixing and economic data.",
       "parameterType": "globeSelect",
       "defaultOption": "United Kingdom",
       "ordered": false,
@@ -12,6 +13,7 @@
     {
       "id": "pathogen",
       "label": "Disease",
+      "description": "Select a disease to set model parameters for transmissibility, delays, and severity based on known characteristics of that historical epidemic or epidemic wave.",
       "parameterType": "select",
       "ordered": false,
       "options": null
@@ -19,14 +21,30 @@
     {
       "id": "response",
       "label": "Response",
+      "description": "Select a pandemic mitigation strategy, comprising closures and other restrictions",
       "parameterType": "select",
       "defaultOption": "none",
       "ordered": true,
       "options": [
-        { "id": "none", "label": "No closures" },
-        { "id": "school_closures", "label": "School closures" },
-        { "id": "economic_closures", "label": "Business closures" },
-        { "id": "elimination", "label": "Elimination" }
+        { "id": "none",
+          "label": "No closures",
+          "description": "No pandemic mitigation: all economic sectors are fully open"
+        },
+        {
+          "id": "school_closures",
+          "label": "School closures",
+          "description": "A response strategy of mostly school closures"
+        },
+        {
+          "id": "economic_closures",
+          "label": "Business closures",
+          "description": "A response strategy of mostly economic closures"
+        },
+        {
+          "id": "elimination",
+          "label": "Elimination",
+          "description": "A response strategy aimed at elimination of the disease, including all necessary closures"
+        }
       ]
     },
     {

--- a/inst/json/metadata_0.1.0.json
+++ b/inst/json/metadata_0.1.0.json
@@ -4,7 +4,7 @@
     {
       "id": "country",
       "label": "Country",
-      "description": "Select a country to set model parameters for country-specific demographic, mixing and economic data",
+      "description": "Select a country to set model parameters for country-specific demographic, patterns of social mixing and economic data",
       "parameterType": "globeSelect",
       "defaultOption": "United Kingdom",
       "ordered": false,
@@ -13,7 +13,7 @@
     {
       "id": "pathogen",
       "label": "Disease",
-      "description": "Select a disease to set model parameters for transmissibility, delays, and severity based on known characteristics of that historical epidemic or epidemic wave",
+      "description": "Select a disease to set model parameters for transmissibility, incubation period and severity based on known characteristics of that historical epidemic or epidemic wave",
       "parameterType": "select",
       "ordered": false,
       "options": null
@@ -28,7 +28,7 @@
       "options": [
         { "id": "none",
           "label": "No closures",
-          "description": "No pandemic mitigation: all economic sectors are fully open"
+          "description": "No pandemic mitigation: all sectors are fully open"
         },
         {
           "id": "school_closures",
@@ -50,7 +50,7 @@
     {
       "id": "vaccine",
       "label": "Global vaccine investment",
-      "description": "Select a level of advance global vaccine investment, which determines vaccine rollout start date, administration rate and coverage during the pandemic",
+      "description": "Select a level of advance global vaccine investment, which determines vaccine rollout start date, administration rate and population coverage during the pandemic",
       "parameterType": "select",
       "defaultOption": "none",
       "ordered": true,

--- a/inst/schema/metadata.json
+++ b/inst/schema/metadata.json
@@ -25,6 +25,7 @@
           "properties": {
             "id": { "type": "string" },
             "label": { "type": "string" },
+            "description": { "type": "string" },
             "parameterType": {
               "type": "string",
               "enum": ["select", "globeSelect", "numeric"]
@@ -36,20 +37,7 @@
             "options": {
               "type": "array",
               "items": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string"
-                  },
-                  "label": {
-                    "type": "string"
-                  }
-                },
-                "additionalProperties": false,
-                "required": [
-                  "id",
-                  "label"
-                ]
+                "$ref": "#/$defs/displayInfo"
               }
             },
             "step": { "type": "number" },

--- a/inst/schema/scenarioResults.json
+++ b/inst/schema/scenarioResults.json
@@ -35,10 +35,6 @@
                 "type": "object",
                 "properties": {
                     "id": { "type":  "string" },
-                    "level": {
-                        "type": "string",
-                        "enum": ["light", "heavy"]
-                    },
                     "start": { "type": "number" },
                     "end": { "type": "number" }
                 },

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -38,11 +38,11 @@ test_that("can get nested costs", {
 })
 
 test_that("can get vaccine option description", {
-  res <- get_vaccine_option_description("high")
+  res <- get_vaccine_option_description("medium")
   expected <- stringr::str_glue(
     "An investment level corresponding to: ",
-    "vaccine rollout commencing 100 days after the outbreak starts, ",
-    "a vaccine administration rate of 0.5% of population per day, ",
+    "vaccine rollout commencing 200 days after the outbreak starts, ",
+    "a vaccine administration rate of 0.43% of population per day, ",
     "and an upper limit of vaccine coverage of 80% of the general population"
   )
   expect_identical(res, expected)

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -36,3 +36,14 @@ test_that("can get nested costs", {
   costs <- get_nested_costs(raw_costs)
   expect_nested_mock_costs(costs)
 })
+
+test_that("can get vaccine option description", {
+  res <- get_vaccine_option_description("high")
+  expected <- stringr::str_glue(
+    "An investment level corresponding to: ",
+    "vaccine rollout commencing 100 days after the outbreak starts, ",
+    "a vaccine administration rate of 0.5% of population per day, ",
+    "and an upper limit of vaccine coverage of 80% of the general population"
+  )
+  expect_identical(res, expected)
+})

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -43,7 +43,7 @@ test_that("can get vaccine option description", {
     "An investment level corresponding to: ",
     "vaccine rollout commencing 200 days after the outbreak starts, ",
     "a vaccine administration rate of 0.43% of population per day, ",
-    "and an upper limit of vaccine coverage of 80% of the general population"
+    "and an upper limit of vaccine coverage of 60% of the general population"
   )
   expect_identical(res, expected)
 })

--- a/tests/testthat/test-zzz-e2e.R
+++ b/tests/testthat/test-zzz-e2e.R
@@ -1,4 +1,3 @@
-skip()
 check_for_redis()
 temp_dir <- tempdir()
 # Env vars required by the queue

--- a/tests/testthat/test-zzz-e2e.R
+++ b/tests/testthat/test-zzz-e2e.R
@@ -78,6 +78,8 @@ test_that("can run model, get status and results", {
   results_url <- paste0("/scenario/results/", run_id) # nolint
   results_response <- bg$request("GET", results_url)
   results_body <- httr::content(results_response)
+  print("RESULTS")
+  print(results_body)
 
   expect_identical(httr::status_code(results_response), 200L)
   results_data <- results_body$data

--- a/tests/testthat/test-zzz-e2e.R
+++ b/tests/testthat/test-zzz-e2e.R
@@ -1,3 +1,4 @@
+skip()
 check_for_redis()
 temp_dir <- tempdir()
 # Env vars required by the queue

--- a/tests/testthat/test_model_run.R
+++ b/tests/testthat/test_model_run.R
@@ -3,7 +3,6 @@ test_that("can run model and return results", {
   mock_results <- list(
     model_data = mock_model_data,
     response_data = list(
-      implementation_level = "heavy",
       closure_info = list(
         closure_time_start = 11,
         closure_time_end = 79
@@ -54,7 +53,6 @@ test_that("can run model and return results", {
   expect_identical(res$interventions, list(
     list(
       id = "response",
-      level = "heavy",
       start = 11,
       end = 79
     )


### PR DESCRIPTION
This branch adds help text for parameters and their options. 

The text is stored in the metadata json file, except for the vaccine investment options, where we plug in values for vaccination start, rate and coverage into a template string using values taken from the package for each investment level.  

Also updates for the latest version of the package, which meant removing the old intervention level. 