### PR TITLE
jidea-116 make default country Thailand and rename child age groups

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -106,8 +106,8 @@ get_nested_costs <- function(raw_costs) {
         cost_item("education_absences", education_absences)
       )),
       cost_item("life_years", life_years, list(
-        cost_item("life_years_infants", life_years_age[["0-4"]]),
-        cost_item("life_years_adolescents", life_years_age[["5-19"]]),
+        cost_item("life_years_pre_school", life_years_age[["0-4"]]),
+        cost_item("life_years_school_age", life_years_age[["5-19"]]),
         cost_item("life_years_working_age", life_years_age[["20-65"]]),
         cost_item("life_years_retirement_age", life_years_age[["65+"]])
       ))

--- a/inst/json/metadata_0.1.0.json
+++ b/inst/json/metadata_0.1.0.json
@@ -81,7 +81,7 @@
       { "id": "education_closures", "label": "Closures" },
       { "id": "education_absences", "label": "Absences" },
       { "id": "life_years", "label": "Life years" },
-      { "id": "life_years_pre_school", "label": "Pre-school-age children"},
+      { "id": "life_years_pre_school", "label": "Preschool-age children"},
       { "id": "life_years_school_age", "label": "School-age children" },
       { "id": "life_years_working_age", "label": "Working-age adults" },
       { "id": "life_years_retirement_age", "label": "Retirement-age adults" }

--- a/inst/json/metadata_0.1.0.json
+++ b/inst/json/metadata_0.1.0.json
@@ -6,7 +6,7 @@
       "label": "Country",
       "description": "Select a country to set model parameters for country-specific demographic, patterns of social mixing and economic data",
       "parameterType": "globeSelect",
-      "defaultOption": "United Kingdom",
+      "defaultOption": "Thailand",
       "ordered": false,
       "options": null
     },
@@ -81,8 +81,8 @@
       { "id": "education_closures", "label": "Closures" },
       { "id": "education_absences", "label": "Absences" },
       { "id": "life_years", "label": "Life years" },
-      { "id": "life_years_infants", "label": "Infants" },
-      { "id": "life_years_adolescents", "label": "Adolescents" },
+      { "id": "life_years_pre_school", "label": "Pre-school-age children"},
+      { "id": "life_years_school_age", "label": "School-age children" },
       { "id": "life_years_working_age", "label": "Working-age adults" },
       { "id": "life_years_retirement_age", "label": "Retirement-age adults" }
     ],

--- a/tests/testthat/helper-daedalus-api.R
+++ b/tests/testthat/helper-daedalus-api.R
@@ -86,15 +86,15 @@ expect_nested_mock_costs <- function(costs) {
   expect_identical(life_years$value, 50)
   expect_length(life_years$children, 4L)
 
-  life_years_infants <- life_years$children[[1]]
-  expect_identical(life_years_infants$id, "life_years_infants")
-  expect_identical(life_years_infants$value, 5)
-  expect_false("children" %in% names(life_years_infants))
+  life_years_pre_school <- life_years$children[[1]]
+  expect_identical(life_years_pre_school$id, "life_years_school_age")
+  expect_identical(life_years_pre_school$value, 5)
+  expect_false("children" %in% names(life_years_pre_school))
 
-  life_years_adolescents <- life_years$children[[2]]
-  expect_identical(life_years_adolescents$id, "life_years_adolescents")
-  expect_identical(life_years_adolescents$value, 10)
-  expect_false("children" %in% names(life_years_adolescents))
+  life_years_school_age <- life_years$children[[2]]
+  expect_identical(life_years_school_age$id, "life_years_pre_school")
+  expect_identical(life_years_school_age$value, 10)
+  expect_false("children" %in% names(life_years_school_age))
 
   life_years_working_age <- life_years$children[[3]]
   expect_identical(life_years_working_age$id, "life_years_working_age")

--- a/tests/testthat/helper-daedalus-api.R
+++ b/tests/testthat/helper-daedalus-api.R
@@ -87,12 +87,12 @@ expect_nested_mock_costs <- function(costs) {
   expect_length(life_years$children, 4L)
 
   life_years_pre_school <- life_years$children[[1]]
-  expect_identical(life_years_pre_school$id, "life_years_school_age")
+  expect_identical(life_years_pre_school$id, "life_years_pre_school")
   expect_identical(life_years_pre_school$value, 5)
   expect_false("children" %in% names(life_years_pre_school))
 
   life_years_school_age <- life_years$children[[2]]
-  expect_identical(life_years_school_age$id, "life_years_pre_school")
+  expect_identical(life_years_school_age$id, "life_years_school_age")
   expect_identical(life_years_school_age$value, 10)
   expect_false("children" %in% names(life_years_school_age))
 

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -68,7 +68,7 @@ test_that("Can get metadata", {
     }, character(1)),
     daedalus_countries
   )
-  expect_identical(params[[country_idx]]$defaultOption, "United Kingdom")
+  expect_identical(params[[country_idx]]$defaultOption, "Thailand")
   hosp_cap_idx <- match("hospital_capacity", expected_parameters)
   update_values <- res$data$parameters[[hosp_cap_idx]]$updateNumericFrom$values
   expect_named(update_values, daedalus_countries)

--- a/tests/testthat/test-zzz-e2e.R
+++ b/tests/testthat/test-zzz-e2e.R
@@ -119,17 +119,17 @@ test_that("can run model, get status and results", {
                sum(education_closures$value,
                    education_absences$value),
                tolerance = tolerance)
-  lifeyears_infants <- life_years_total$children[[1]]
-  expect_identical(lifeyears_infants$id, "life_years_infants")
-  lifeyears_adolescents <- life_years_total$children[[2]]
-  expect_identical(lifeyears_adolescents$id, "life_years_adolescents")
+  lifeyears_pre_school <- life_years_total$children[[1]]
+  expect_identical(lifeyears_pre_school$id, "life_years_pre_school")
+  lifeyears_school_age <- life_years_total$children[[2]]
+  expect_identical(lifeyears_school_age$id, "life_years_school_age")
   lifeyears_working_age <- life_years_total$children[[3]]
   expect_identical(lifeyears_working_age$id, "life_years_working_age")
   lifeyears_retirement_age <- life_years_total$children[[4]]
   expect_identical(lifeyears_retirement_age$id, "life_years_retirement_age")
   expect_equal(life_years_total$value,
-               sum(lifeyears_infants$value,
-                   lifeyears_adolescents$value,
+               sum(lifeyears_pre_school$value,
+                   lifeyears_school_age$value,
                    lifeyears_working_age$value,
                    lifeyears_retirement_age$value),
                tolerance = tolerance)


### PR DESCRIPTION
This branch makes Thailand the default country now that it is supported by the model.

This branch also opportunistically does the rename of child age groups as discussed in today's Dashboard meeting:
infants --> pre-school-age children
adolescents --> school-age children  