### PR TITLE
Re-describe vaccination time series results

### DIFF
--- a/inst/json/metadata_0.1.0.json
+++ b/inst/json/metadata_0.1.0.json
@@ -107,7 +107,7 @@
         "description": "Number of infectious individuals, comprising both symptomatic and asymptomatic infections, including those in need of hospitalisation." },
       { "id": "hospitalised", "label": "Hospital demand", "description": "Infections requiring hospitalisation" },
       { "id": "dead", "label": "Dead", "description": "Total deaths" },
-      { "id": "vaccinated", "label": "Vaccinated", "description": "Total vaccinated" }
+      { "id": "vaccinated", "label": "Vaccinated", "description": "Total number of vaccinations administered" }
     ]
   }
 }


### PR DESCRIPTION
Since we've agreed to include dead in this count (because it's the level of administration that is most relevant to policy-makers) I suggest this new description of the time series data.

Merge at will.