### PR TITLE
jidea-136 use iso3 codes as country ids

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus.api
 Title: Serve the 'daedalus' model via an API
-Version: 0.0.5
+Version: 0.0.6
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/R/api.R
+++ b/R/api.R
@@ -58,11 +58,11 @@ metadata <- function() {
 
   # Set available countries from daedalus package
   # JIDEA-62: use the right version of daedalus/model
-  # we will get ISO ids from daedalus when available
   country_names <- daedalus::country_names
+  country_codes <- daedalus::country_codes_iso3c
 
-  country_options <- lapply(country_names, function(country) {
-    get_option(country, country)
+  country_options <- lapply(seq_along(country_names), function(idx) {
+    get_option(country_codes[[idx]], country_names[[idx]])
   })
   country_idx <- match("country", param_ids)
   response$parameters[[country_idx]]$options <- country_options
@@ -84,9 +84,11 @@ metadata <- function() {
   step <- response$parameters[[hospital_capacity_idx]]$step
   # setNames to get json object not array
   hospital_capacities <- lapply(
-    setNames(country_names, country_names),
-    function(country) {
-      default <- daedalus::daedalus_country(country)$hospital_capacity
+    setNames(country_codes, country_codes),
+    function(country_code) {
+      idx <- match(country_code, country_codes)
+      country_name <- country_names[[idx]]
+      default <- daedalus::daedalus_country(country_name)$hospital_capacity
       get_hospital_capacity_range(default, step)
   })
 

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -53,26 +53,27 @@ test_that("Can get metadata", {
   )
   country_idx <- match("country", expected_parameters)
   country_options <- params[[country_idx]]$options
-  daedalus_countries <- daedalus::country_names
+  daedalus_country_codes <- daedalus::country_codes_iso3c
   # expect country ids to match those from daedalus
   expect_identical(
     vapply(country_options, function(option) {
         option$id
     }, character(1)),
-    daedalus_countries
+    daedalus_country_codes
   )
   # expect country labels to match those from daedalus
+  daedalus_country_names <- daedalus::country_names
   expect_identical(
     vapply(country_options, function(option) {
       option$label
     }, character(1)),
-    daedalus_countries
+    daedalus_country_names
   )
   expect_identical(params[[country_idx]]$defaultOption, "Thailand")
   hosp_cap_idx <- match("hospital_capacity", expected_parameters)
   update_values <- res$data$parameters[[hosp_cap_idx]]$updateNumericFrom$values
-  expect_named(update_values, daedalus_countries)
-  for (country in daedalus_countries) {
+  expect_named(update_values, daedalus_country_codes)
+  for (country in daedalus_country_codes) {
     values <- update_values[[country]]
     expect_identical(values$min %% 100, 0)
     expect_identical(values$default %% 100, 0)


### PR DESCRIPTION
Provide country option ids as iso3 codes rather than country names. Similarly for the `updateNumericFrom` hospital capacity values. 

TODO: when https://github.com/jameel-institute/daedalus/pull/38 is merged, use latest version of package so we can accept those codes when running the model. 