### PR TITLE
jidea-110 New time series

### DIFF
--- a/R/model_run.R
+++ b/R/model_run.R
@@ -46,11 +46,11 @@ model_run <- function(parameters, model_version) {
   incidences <- tidyr::pivot_wider(
     incidences, id_cols = "time", names_from = "measure"
   )
-  time_series$new_infections <- incidences$daily_infections
-  time_series$new_hospitalisations <- incidences$daily_hospitalisations
-  time_series$new_deaths <- incidences$daily_deaths
+  time_series$new_infected <- incidences$daily_infections
+  time_series$new_hospitalised <- incidences$daily_hospitalisations
+  time_series$new_dead <- incidences$daily_deaths
 
-  time_series$new_vaccinations <-
+  time_series$new_vaccinated <-
     daedalus::get_new_vaccinations(model_results)$new_vaccinations
 
   raw_costs <- daedalus::get_costs(model_results)

--- a/R/model_run.R
+++ b/R/model_run.R
@@ -42,10 +42,14 @@ model_run <- function(parameters, model_version) {
   time_series$vaccinated <- vax_time_series$vaccinated
 
   # get incidence time series
-  time_series$new_infections <- daedalus::get_incidence(model_results, "infections")$value
-  time_series$new_hospitalisations <- daedalus::get_incidence(model_results, "hospitalisations")$value
-  time_series$new_deaths <- daedalus::get_incidence(model_results, "deaths")$value
-  time_series$new_vaccinations <- daedalus::get_new_vaccinations(model_results)$new_vaccinations
+  time_series$new_infections <-
+    daedalus::get_incidence(model_results, "infections")$value
+  time_series$new_hospitalisations <-
+    daedalus::get_incidence(model_results, "hospitalisations")$value
+  time_series$new_deaths <-
+    daedalus::get_incidence(model_results, "deaths")$value
+  time_series$new_vaccinations <-
+    daedalus::get_new_vaccinations(model_results)$new_vaccinations
 
   raw_costs <- daedalus::get_costs(model_results)
   costs <- get_nested_costs(raw_costs)

--- a/R/model_run.R
+++ b/R/model_run.R
@@ -43,9 +43,9 @@ model_run <- function(parameters, model_version) {
 
   # get incidence time series
   time_series$new_infections <- daedalus::get_incidence(model_results, "infections")$value
-  time_series$new_hospitalised <- daedalus::get_incidence(model_results, "hospitalisations")$value
+  time_series$new_hospitalisations <- daedalus::get_incidence(model_results, "hospitalisations")$value
   time_series$new_deaths <- daedalus::get_incidence(model_results, "deaths")$value
-  time_series$new_vaccinated <- daedalus::get_new_vaccinations(model_results)$new_vaccinations
+  time_series$new_vaccinations <- daedalus::get_new_vaccinations(model_results)$new_vaccinations
 
   raw_costs <- daedalus::get_costs(model_results)
   costs <- get_nested_costs(raw_costs)

--- a/R/model_run.R
+++ b/R/model_run.R
@@ -42,12 +42,14 @@ model_run <- function(parameters, model_version) {
   time_series$vaccinated <- vax_time_series$vaccinated
 
   # get incidence time series
-  time_series$new_infections <-
-    daedalus::get_incidence(model_results, "infections")$value
-  time_series$new_hospitalisations <-
-    daedalus::get_incidence(model_results, "hospitalisations")$value
-  time_series$new_deaths <-
-    daedalus::get_incidence(model_results, "deaths")$value
+  incidences <- daedalus::get_incidence(model_results)
+  incidences <- tidyr::pivot_wider(
+    incidences, id_cols = "time", names_from = "measure"
+  )
+  time_series$new_infections <- incidences$daily_infections
+  time_series$new_hospitalisations <- incidences$daily_hospitalisations
+  time_series$new_deaths <- incidences$daily_deaths
+
   time_series$new_vaccinations <-
     daedalus::get_new_vaccinations(model_results)$new_vaccinations
 

--- a/R/model_run.R
+++ b/R/model_run.R
@@ -41,6 +41,12 @@ model_run <- function(parameters, model_version) {
   )
   time_series$vaccinated <- vax_time_series$vaccinated
 
+  # get incidence time series
+  time_series$new_infections <- daedalus::get_incidence(model_results, "infections")$value
+  time_series$new_hospitalised <- daedalus::get_incidence(model_results, "hospitalisations")$value
+  time_series$new_deaths <- daedalus::get_incidence(model_results, "deaths")$value
+  time_series$new_vaccinated <- daedalus::get_new_vaccinations(model_results)$new_vaccinations
+
   raw_costs <- daedalus::get_costs(model_results)
   costs <- get_nested_costs(raw_costs)
 

--- a/inst/json/metadata_0.1.0.json
+++ b/inst/json/metadata_0.1.0.json
@@ -109,7 +109,7 @@
       { "id": "dead", "label": "Dead", "description": "Total deaths" },
       { "id": "vaccinated", "label": "Vaccinated", "description": "Total number of vaccinations administered" },
       { "id": "new_infected", "label": "New infections", "description": "Number of new infections per day" },
-      { "id": "new_hospitalised", "label": "New hospitalisations", "description": "Number of patients who are hospitalised per day" },
+      { "id": "new_hospitalised", "label": "New hospitalisations", "description": "Number of new patients in need of hospitalisation per day" },
       { "id": "new_dead", "label": "New deaths", "description": "Number of deaths per day" },
       { "id": "new_vaccinated", "label": "New vaccinations", "description": "Number of vaccinations per day" }
     ],

--- a/inst/json/metadata_0.1.0.json
+++ b/inst/json/metadata_0.1.0.json
@@ -107,7 +107,11 @@
         "description": "Number of infectious individuals, comprising both symptomatic and asymptomatic infections, including those in need of hospitalisation." },
       { "id": "hospitalised", "label": "Hospital demand", "description": "Infections requiring hospitalisation" },
       { "id": "dead", "label": "Dead", "description": "Total deaths" },
-      { "id": "vaccinated", "label": "Vaccinated", "description": "Total number of vaccinations administered" }
+      { "id": "vaccinated", "label": "Vaccinated", "description": "Total number of vaccinations administered" },
+      { "id": "new_infections", "label": "New Infections", "description": "Number of new infections per day" },
+      { "id": "new_hospitalisations", "label": "New Hospitalisations", "description": "Number of patients who are hospitalised per day" },
+      { "id": "new_deaths", "label": "New deaths", "description": "Number of deaths per day" },
+      { "id": "new_vaccinations", "label": "New vaccinations", "descriptions": "Number of vaccinations per day" }
     ]
   }
 }

--- a/inst/json/metadata_0.1.0.json
+++ b/inst/json/metadata_0.1.0.json
@@ -108,10 +108,10 @@
       { "id": "hospitalised", "label": "Hospital demand", "description": "Infections requiring hospitalisation" },
       { "id": "dead", "label": "Dead", "description": "Total deaths" },
       { "id": "vaccinated", "label": "Vaccinated", "description": "Total number of vaccinations administered" },
-      { "id": "new_infections", "label": "New Infections", "description": "Number of new infections per day" },
-      { "id": "new_hospitalisations", "label": "New Hospitalisations", "description": "Number of patients who are hospitalised per day" },
-      { "id": "new_deaths", "label": "New deaths", "description": "Number of deaths per day" },
-      { "id": "new_vaccinations", "label": "New vaccinations", "description": "Number of vaccinations per day" }
+      { "id": "new_infected", "label": "New infections", "description": "Number of new infections per day" },
+      { "id": "new_hospitalised", "label": "New hospitalisations", "description": "Number of patients who are hospitalised per day" },
+      { "id": "new_dead", "label": "New deaths", "description": "Number of deaths per day" },
+      { "id": "new_vaccinated", "label": "New vaccinations", "description": "Number of vaccinations per day" }
     ],
     "time_series_roles": [
       {"id": "total", "label": "Total"},
@@ -123,7 +123,7 @@
         "label": "Infections",
         "time_series": {
           "total": "prevalence",
-          "daily": "new_infections"
+          "daily": "new_infected"
         }
       },
       {
@@ -131,7 +131,7 @@
         "label": "Hospitalisations",
         "time_series": {
           "total": "hospitalised",
-          "daily": "new_hospitalisations"
+          "daily": "new_hospitalised"
         }
       },
       {
@@ -139,7 +139,7 @@
         "label": "Deaths",
         "time_series": {
           "total": "dead",
-          "daily": "new_deaths"
+          "daily": "new_dead"
         }
       },
       {
@@ -147,7 +147,7 @@
         "label": "Vaccinations",
         "time_series": {
           "total": "vaccinated",
-          "daily": "new_vaccinations"
+          "daily": "new_vaccinated"
         }
       }
     ]

--- a/inst/json/metadata_0.1.0.json
+++ b/inst/json/metadata_0.1.0.json
@@ -111,45 +111,45 @@
       { "id": "new_infections", "label": "New Infections", "description": "Number of new infections per day" },
       { "id": "new_hospitalisations", "label": "New Hospitalisations", "description": "Number of patients who are hospitalised per day" },
       { "id": "new_deaths", "label": "New deaths", "description": "Number of deaths per day" },
-      { "id": "new_vaccinations", "label": "New vaccinations", "descriptions": "Number of vaccinations per day" }
+      { "id": "new_vaccinations", "label": "New vaccinations", "description": "Number of vaccinations per day" }
+    ],
+    "time_series_roles": [
+      {"id": "total", "label": "Total"},
+      {"id":  "daily", "label": "Daily"}
+    ],
+    "time_series_groups": [
+      {
+        "id": "infections",
+        "label": "Infections",
+        "time_series": {
+          "total": "prevalence",
+          "daily": "new_infections"
+        }
+      },
+      {
+        "id": "hospitalisations",
+        "label": "Hospitalisations",
+        "time_series": {
+          "total": "hospitalised",
+          "daily": "new_hospitalisations"
+        }
+      },
+      {
+        "id": "deaths",
+        "label": "Deaths",
+        "time_series": {
+          "total": "dead",
+          "daily": "new_deaths"
+        }
+      },
+      {
+        "id": "vaccinations",
+        "label": "Vaccinations",
+        "time_series": {
+          "total": "vaccinated",
+          "daily": "new_vaccinations"
+        }
+      }
     ]
-  },
-  "time_series_roles": [
-    {"id": "total", "label":  "Total"},
-    {"id":  "daily", "label":  "Daily"}
-  ],
-  "time_series_groups": [
-    {
-      "id": "infections",
-      "label": "Infections",
-      "time_series": {
-        "total": "prevalence",
-        "daily": "new_infections"
-      }
-    },
-    {
-      "id": "hospitalisations",
-      "label": "Hospitalisations",
-      "time_series": {
-        "total": "hospitalised",
-        "daily": "new_hospitalisations"
-      }
-    },
-    {
-      "id": "deaths",
-      "label": "Deaths",
-      "time_series": {
-        "total": "dead",
-        "daily": "new_deaths"
-      }
-    },
-    {
-      "id": "vaccinations",
-      "label": "Vaccinations",
-      "time_series": {
-        "total": "vaccinated",
-        "daily": "new_vaccinations"
-      }
-    }
-  ]
+  }
 }

--- a/inst/json/metadata_0.1.0.json
+++ b/inst/json/metadata_0.1.0.json
@@ -113,5 +113,43 @@
       { "id": "new_deaths", "label": "New deaths", "description": "Number of deaths per day" },
       { "id": "new_vaccinations", "label": "New vaccinations", "descriptions": "Number of vaccinations per day" }
     ]
-  }
+  },
+  "time_series_roles": [
+    {"id": "total", "label":  "Total"},
+    {"id":  "daily", "label":  "Daily"}
+  ],
+  "time_series_groups": [
+    {
+      "id": "infections",
+      "label": "Infections",
+      "time_series": {
+        "total": "prevalence",
+        "daily": "new_infections"
+      }
+    },
+    {
+      "id": "hospitalisations",
+      "label": "Hospitalisations",
+      "time_series": {
+        "total": "hospitalised",
+        "daily": "new_hospitalisations"
+      }
+    },
+    {
+      "id": "deaths",
+      "label": "Deaths",
+      "time_series": {
+        "total": "dead",
+        "daily": "new_deaths"
+      }
+    },
+    {
+      "id": "vaccinations",
+      "label": "Vaccinations",
+      "time_series": {
+        "total": "vaccinated",
+        "daily": "new_vaccinations"
+      }
+    }
+  ]
 }

--- a/inst/schema/metadata.json
+++ b/inst/schema/metadata.json
@@ -93,6 +93,25 @@
             "items": {
               "$ref": "#/$defs/displayInfo"
             }
+          },
+          "time_series_roles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/displayInfo"
+            }
+          },
+          "time_series_groups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "label": { "type": "string" },
+                "time_series": { "type": "object" }
+              },
+              "additionalProperties": false,
+              "required": ["id", "label", "time_series"]
+            }
           }
         },
         "additionalProperties": false,

--- a/tests/testthat/test-zzz-e2e.R
+++ b/tests/testthat/test-zzz-e2e.R
@@ -1,3 +1,4 @@
+skip()
 check_for_redis()
 temp_dir <- tempdir()
 # Env vars required by the queue
@@ -91,6 +92,10 @@ test_that("can run model, get status and results", {
   expect_length(results_data$time_series$prevalence, time_series_length)
   expect_length(results_data$time_series$hospitalised, time_series_length)
   expect_length(results_data$time_series$dead, time_series_length)
+  expect_length(results_data$time_series$new_infections, time_series_length)
+  expect_length(results_data$time_series$new_hospitalisations, time_series_length)
+  expect_length(results_data$time_series$new_deaths, time_series_length)
+  expect_length(results_data$time_series$new_vaccinations, time_series_length)
 
   expect_gt(results_data$gdp, 0)
 

--- a/tests/testthat/test-zzz-e2e.R
+++ b/tests/testthat/test-zzz-e2e.R
@@ -92,7 +92,8 @@ test_that("can run model, get status and results", {
   expect_length(results_data$time_series$hospitalised, time_series_length)
   expect_length(results_data$time_series$dead, time_series_length)
   expect_length(results_data$time_series$new_infections, time_series_length)
-  expect_length(results_data$time_series$new_hospitalisations, time_series_length)
+  expect_length(results_data$time_series$new_hospitalisations,
+                time_series_length)
   expect_length(results_data$time_series$new_deaths, time_series_length)
   expect_length(results_data$time_series$new_vaccinations, time_series_length)
 

--- a/tests/testthat/test-zzz-e2e.R
+++ b/tests/testthat/test-zzz-e2e.R
@@ -1,4 +1,3 @@
-skip()
 check_for_redis()
 temp_dir <- tempdir()
 # Env vars required by the queue

--- a/tests/testthat/test-zzz-e2e.R
+++ b/tests/testthat/test-zzz-e2e.R
@@ -91,11 +91,11 @@ test_that("can run model, get status and results", {
   expect_length(results_data$time_series$prevalence, time_series_length)
   expect_length(results_data$time_series$hospitalised, time_series_length)
   expect_length(results_data$time_series$dead, time_series_length)
-  expect_length(results_data$time_series$new_infections, time_series_length)
-  expect_length(results_data$time_series$new_hospitalisations,
+  expect_length(results_data$time_series$new_infected, time_series_length)
+  expect_length(results_data$time_series$new_hospitalised,
                 time_series_length)
-  expect_length(results_data$time_series$new_deaths, time_series_length)
-  expect_length(results_data$time_series$new_vaccinations, time_series_length)
+  expect_length(results_data$time_series$new_dead, time_series_length)
+  expect_length(results_data$time_series$new_vaccinated, time_series_length)
 
   expect_gt(results_data$gdp, 0)
 

--- a/tests/testthat/test_model_run.R
+++ b/tests/testthat/test_model_run.R
@@ -15,7 +15,7 @@ test_that("can run model and return results", {
   mockery::stub(model_run, "daedalus::get_data", mock_model_data)
 
   mock_incidence_result <- list(value = c(10, 20))
-  mock_get_incidence <- mockery::mock(mock_incidence_result)
+  mock_get_incidence <- mockery::mock(mock_incidence_result, cycle=TRUE)
   mockery::stub(model_run, "daedalus::get_incidence", mock_get_incidence)
 
   mock_new_vaccinations_result <- list(new_vaccinations = c(100, 200))
@@ -63,7 +63,11 @@ test_that("can run model and return results", {
   expect_named(res$time_series, c("prevalence",
                                   "hospitalised",
                                   "dead",
-                                  "vaccinated"))
+                                  "vaccinated",
+                                  "new_infections",
+                                  "new_hospitalisations",
+                                  "new_deaths",
+                                  "new_vaccinations"))
   expect_identical(res$time_series$prevalence, c(28L, 87L))
   expect_identical(res$time_series$hospitalised, c(11L, 31L))
   expect_identical(res$time_series$dead, c(15L, 37L))

--- a/tests/testthat/test_model_run.R
+++ b/tests/testthat/test_model_run.R
@@ -15,11 +15,13 @@ test_that("can run model and return results", {
   mockery::stub(model_run, "daedalus::get_data", mock_model_data)
 
   mock_incidence_result <- list(value = c(10, 20))
-  mock_get_incidence <- mockery::mock(mock_incidence_result, cycle=TRUE)
+  mock_get_incidence <- mockery::mock(mock_incidence_result,
+                                      cycle=TRUE)
   mockery::stub(model_run, "daedalus::get_incidence", mock_get_incidence)
 
   mock_new_vaccinations_result <- list(new_vaccinations = c(100, 200))
-  mockery::stub(model_run, "daedalus::get_new_vaccinations", mock_new_vaccinations_result)
+  mockery::stub(model_run, "daedalus::get_new_vaccinations",
+                mock_new_vaccinations_result)
 
   mock_costs_data <- daedalus_mock_costs()
   mock_get_costs <- mockery::mock(mock_costs_data)
@@ -80,9 +82,11 @@ test_that("can run model and return results", {
   expect_identical(res$time_series$dead, c(15L, 37L))
   expect_identical(res$time_series$vaccinated, c(1L, 5L))
   expect_identical(res$time_series$new_infections, mock_incidence_result$value)
-  expect_identical(res$time_series$new_hospitalisations, mock_incidence_result$value)
+  expect_identical(res$time_series$new_hospitalisations,
+                   mock_incidence_result$value)
   expect_identical(res$time_series$new_deaths, mock_incidence_result$value)
-  expect_identical(res$time_series$new_vaccinations, mock_new_vaccinations_result$new_vaccinations)
+  expect_identical(res$time_series$new_vaccinations,
+                   mock_new_vaccinations_result$new_vaccinations)
   expect_identical(res$parameters, parameters)
   expect_nested_mock_costs(res$costs)
   expect_identical(res$interventions, list(

--- a/tests/testthat/test_model_run.R
+++ b/tests/testthat/test_model_run.R
@@ -14,6 +14,13 @@ test_that("can run model and return results", {
 
   mockery::stub(model_run, "daedalus::get_data", mock_model_data)
 
+  mock_incidence_result <- list(value = c(10, 20))
+  mock_get_incidence <- mockery::mock(mock_incidence_result)
+  mockery::stub(model_run, "daedalus::get_incidence", mock_get_incidence)
+
+  mock_new_vaccinations_result <- list(new_vaccinations = c(100, 200))
+  mockery::stub(model_run, "daedalus::get_new_vaccinations", mock_new_vaccinations_result)
+
   mock_costs_data <- daedalus_mock_costs()
   mock_get_costs <- mockery::mock(mock_costs_data)
   mockery::stub(model_run, "daedalus::get_costs", mock_get_costs)
@@ -39,6 +46,12 @@ test_that("can run model and return results", {
     )
   )
 
+  expect_identical(
+    mockery::mock_args(mock_get_incidence)[[1]],
+    list(mock_results, "infections")
+  )
+  # TODO check other calls
+
   expect_named(res, c(
     "parameters",
     "costs",
@@ -55,6 +68,10 @@ test_that("can run model and return results", {
   expect_identical(res$time_series$hospitalised, c(11L, 31L))
   expect_identical(res$time_series$dead, c(15L, 37L))
   expect_identical(res$time_series$vaccinated, c(1L, 5L))
+  expect_identical(res$time_series$new_infections, mock_incidence_result$value)
+  expect_identical(res$time_series$new_hospitalisations, mock_incidence_result$value)
+  expect_identical(res$time_series$new_deaths, mock_incidence_result$value)
+  expect_identical(res$time_series$new_vaccinations, mock_new_vaccinations_result$new_vaccinations)
   expect_identical(res$parameters, parameters)
   expect_nested_mock_costs(res$costs)
   expect_identical(res$interventions, list(

--- a/tests/testthat/test_model_run.R
+++ b/tests/testthat/test_model_run.R
@@ -16,7 +16,7 @@ test_that("can run model and return results", {
 
   mock_incidence_result <- list(value = c(10, 20))
   mock_get_incidence <- mockery::mock(mock_incidence_result,
-                                      cycle=TRUE)
+                                      cycle = TRUE)
   mockery::stub(model_run, "daedalus::get_incidence", mock_get_incidence)
 
   mock_new_vaccinations_result <- list(new_vaccinations = c(100, 200))

--- a/tests/testthat/test_model_run.R
+++ b/tests/testthat/test_model_run.R
@@ -19,7 +19,8 @@ test_that("can run model and return results", {
     measure = c("daily_infections", "daily_infections",
                 "daily_hospitalisations", "daily_hospitalisations",
                 "daily_deaths", "daily_deaths"),
-    value = c(100L, 200L, 10L, 20L, 1L, 2L)
+    value = c(100L, 200L, 10L, 20L, 1L, 2L),
+    stringsAsFactors = FALSE
   )
   mock_get_incidence <- mockery::mock(mock_incidence_result,
                                       cycle = TRUE)

--- a/tests/testthat/test_model_run.R
+++ b/tests/testthat/test_model_run.R
@@ -16,7 +16,9 @@ test_that("can run model and return results", {
 
   mock_incidence_result <- data.frame(
     time = c(1, 2, 1, 2, 1, 2),
-    measure = c("daily_infections", "daily_infections", "daily_hospitalisations", "daily_hospitalisations", "daily_deaths", "daily_deaths"),
+    measure = c("daily_infections", "daily_infections",
+                "daily_hospitalisations", "daily_hospitalisations",
+                "daily_deaths", "daily_deaths"),
     value = c(100L, 200L, 10L, 20L, 1L, 2L)
   )
   mock_get_incidence <- mockery::mock(mock_incidence_result,

--- a/tests/testthat/test_model_run.R
+++ b/tests/testthat/test_model_run.R
@@ -14,7 +14,11 @@ test_that("can run model and return results", {
 
   mockery::stub(model_run, "daedalus::get_data", mock_model_data)
 
-  mock_incidence_result <- list(value = c(10, 20))
+  mock_incidence_result <- data.frame(
+    time = c(1, 2, 1, 2, 1, 2),
+    measure = c("daily_infections", "daily_infections", "daily_hospitalisations", "daily_hospitalisations", "daily_deaths", "daily_deaths"),
+    value = c(100L, 200L, 10L, 20L, 1L, 2L)
+  )
   mock_get_incidence <- mockery::mock(mock_incidence_result,
                                       cycle = TRUE)
   mockery::stub(model_run, "daedalus::get_incidence", mock_get_incidence)
@@ -50,15 +54,7 @@ test_that("can run model and return results", {
 
   expect_identical(
     mockery::mock_args(mock_get_incidence)[[1]],
-    list(mock_results, "infections")
-  )
-  expect_identical(
-    mockery::mock_args(mock_get_incidence)[[2]],
-    list(mock_results, "hospitalisations")
-  )
-  expect_identical(
-    mockery::mock_args(mock_get_incidence)[[3]],
-    list(mock_results, "deaths")
+    list(mock_results)
   )
 
   expect_named(res, c(
@@ -81,10 +77,9 @@ test_that("can run model and return results", {
   expect_identical(res$time_series$hospitalised, c(11L, 31L))
   expect_identical(res$time_series$dead, c(15L, 37L))
   expect_identical(res$time_series$vaccinated, c(1L, 5L))
-  expect_identical(res$time_series$new_infections, mock_incidence_result$value)
-  expect_identical(res$time_series$new_hospitalisations,
-                   mock_incidence_result$value)
-  expect_identical(res$time_series$new_deaths, mock_incidence_result$value)
+  expect_identical(res$time_series$new_infections, c(100L, 200L))
+  expect_identical(res$time_series$new_hospitalisations, c(10L, 20L))
+  expect_identical(res$time_series$new_deaths, c(1L, 2L))
   expect_identical(res$time_series$new_vaccinations,
                    mock_new_vaccinations_result$new_vaccinations)
   expect_identical(res$parameters, parameters)

--- a/tests/testthat/test_model_run.R
+++ b/tests/testthat/test_model_run.R
@@ -50,7 +50,14 @@ test_that("can run model and return results", {
     mockery::mock_args(mock_get_incidence)[[1]],
     list(mock_results, "infections")
   )
-  # TODO check other calls
+  expect_identical(
+    mockery::mock_args(mock_get_incidence)[[2]],
+    list(mock_results, "hospitalisations")
+  )
+  expect_identical(
+    mockery::mock_args(mock_get_incidence)[[3]],
+    list(mock_results, "deaths")
+  )
 
   expect_named(res, c(
     "parameters",

--- a/tests/testthat/test_model_run.R
+++ b/tests/testthat/test_model_run.R
@@ -69,18 +69,18 @@ test_that("can run model and return results", {
                                   "hospitalised",
                                   "dead",
                                   "vaccinated",
-                                  "new_infections",
-                                  "new_hospitalisations",
-                                  "new_deaths",
-                                  "new_vaccinations"))
+                                  "new_infected",
+                                  "new_hospitalised",
+                                  "new_dead",
+                                  "new_vaccinated"))
   expect_identical(res$time_series$prevalence, c(28L, 87L))
   expect_identical(res$time_series$hospitalised, c(11L, 31L))
   expect_identical(res$time_series$dead, c(15L, 37L))
   expect_identical(res$time_series$vaccinated, c(1L, 5L))
-  expect_identical(res$time_series$new_infections, c(100L, 200L))
-  expect_identical(res$time_series$new_hospitalisations, c(10L, 20L))
-  expect_identical(res$time_series$new_deaths, c(1L, 2L))
-  expect_identical(res$time_series$new_vaccinations,
+  expect_identical(res$time_series$new_infected, c(100L, 200L))
+  expect_identical(res$time_series$new_hospitalised, c(10L, 20L))
+  expect_identical(res$time_series$new_dead, c(1L, 2L))
+  expect_identical(res$time_series$new_vaccinated,
                    mock_new_vaccinations_result$new_vaccinations)
   expect_identical(res$parameters, parameters)
   expect_nested_mock_costs(res$costs)


### PR DESCRIPTION
This branch adds time series for new (daily) values for infections, hospitalisations, deaths and vaccinations, using daedalus's `get_incidence` and `get_new_vaccinations` methods. 

It also adds metadata for the new time series, and for groupings of time series. This might overkill, but I wanted the API to provide as much information as possible so that the front end could be as generic as possible - but also has the option to pick and choose which metadata it wants to use. The idea here is that related time_series are grouped together into `time_series_groups`, and each time series in a group takes a particular "role" ie total or daily. The role the time series takes in a group is its key in time_series_groups.times_series, and the top level `time_series_roles` provides metadata for the roles (currently just label but could add description too).  Could also add descriptions for the time series groups, just let me know. 