### PR TITLE
Jidea-138 pathogen descriptions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus.api
 Title: Serve the 'daedalus' model via an API
-Version: 0.0.7
+Version: 0.0.8
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),
@@ -12,7 +12,7 @@ License: MIT + file LICENSE
 URL: https://github.com/jameel-institute/daedalus.api
 BugReports: https://github.com/jameel-institute/daedalus.api/issues
 Imports: 
-    daedalus (>= 0.0.19),
+    daedalus (>= 0.0.22),
     docopt,
     dplyr,
     jsonlite,

--- a/R/api.R
+++ b/R/api.R
@@ -77,6 +77,10 @@ metadata <- function() {
     get_option("influenza_1957", "Influenza 1957"),
     get_option("influenza_1918", "Influenza 1918 (Spanish flu)")
   )
+  pathogen_options <- lapply(pathogen_options, function(option) {
+    option$description <- get_pathogen_option_description(option$id)
+    option
+  })
   pathogen_idx <- match("pathogen", param_ids)
   response$parameters[[pathogen_idx]]$options <- pathogen_options
 

--- a/R/api.R
+++ b/R/api.R
@@ -78,7 +78,7 @@ metadata <- function() {
     get_option("influenza_1918", "Influenza 1918 (Spanish flu)")
   )
   pathogen_options <- lapply(pathogen_options, function(option) {
-    option$description <- get_pathogen_option_description(option$id)
+    option$description <- get_pathogen_description(option$id)
     option
   })
   pathogen_idx <- match("pathogen", param_ids)

--- a/R/util.R
+++ b/R/util.R
@@ -57,7 +57,7 @@ get_vaccine_option_description <- function(vaccine_option) {
   )
 }
 
-get_pathogen_option_description <-  function(pathogen_id) {
+get_pathogen_description <-  function(pathogen_id) {
   # get pathogen information from the package and generate
   # description including R0 and IFR range (across all countries)
   # for the pathogen
@@ -70,7 +70,7 @@ get_pathogen_option_description <-  function(pathogen_id) {
     )
   })
   stringr::str_glue(
-    "A disease with an R0 of {r0} and an infection fatality ratio of ",
+    "A disease with R0 of {r0} and infection fatality ratio ",
     "between {ifr_min_pc}% and {ifr_max_pc}% depending on country",
     ifr_min_pc = signif(min(country_ifrs) * 100, 2),
     ifr_max_pc = signif(max(country_ifrs) * 100, 2),

--- a/R/util.R
+++ b/R/util.R
@@ -63,17 +63,15 @@ get_pathogen_description <-  function(pathogen_id) {
   # for the pathogen
 
   infection <- daedalus::daedalus_infection(pathogen_id)
-  country_ifrs <- sapply(daedalus::country_names, function(country_name) {
-    country <- daedalus::daedalus_country(country_name)
-    weighted.mean(
-      infection$ifr, country$demography
-    )
-  })
+  country_ifrs <- vapply(daedalus::country_data, function(country) {
+    weighted.mean(infection$ifr, country$demography)
+  }, 1.0)
+  ifr_range <- range(country_ifrs)
   stringr::str_glue(
     "A disease with R0 of {r0} and infection fatality ratio ",
     "between {ifr_min_pc}% and {ifr_max_pc}% depending on country",
-    ifr_min_pc = signif(min(country_ifrs) * 100, 2),
-    ifr_max_pc = signif(max(country_ifrs) * 100, 2),
+    ifr_min_pc = signif(ifr_range[[1]] * 100, 2),
+    ifr_max_pc = signif(ifr_range[[2]] * 100, 2),
     r0 = signif(infection$r0, 2)
   )
 }

--- a/R/util.R
+++ b/R/util.R
@@ -57,6 +57,27 @@ get_vaccine_option_description <- function(vaccine_option) {
   )
 }
 
+get_pathogen_option_description <-  function(pathogen_id) {
+  # get pathogen information from the package and generate
+  # description including R0 and IFR range (across all countries)
+  # for the pathogen
+
+  infection <- daedalus::daedalus_infection(id)
+  country_ifrs <- lapply(daedalus::country_names, function(country_name) {
+    country <- daedalus::daedalus_country(country_name)
+    weighted.mean(
+      infection$ifr, country$demography
+    )
+  })
+  stringr::str_glue(
+    "A disease with an R0 of { r0 } and an infection fatality ratio of ",
+    "between { ifr_min } and {ifr_max } depending on country",
+    ifr_min = min(country_ifrs),
+    ifr_max = max(country_ifrs),
+    r0 = infection$r0
+  )
+}
+
 validate_parameters <- function(parameters, metadata) {
   # Expect parameters in model run request to include all and only values
   # specified in metadata

--- a/R/util.R
+++ b/R/util.R
@@ -62,19 +62,19 @@ get_pathogen_option_description <-  function(pathogen_id) {
   # description including R0 and IFR range (across all countries)
   # for the pathogen
 
-  infection <- daedalus::daedalus_infection(id)
-  country_ifrs <- lapply(daedalus::country_names, function(country_name) {
+  infection <- daedalus::daedalus_infection(pathogen_id)
+  country_ifrs <- sapply(daedalus::country_names, function(country_name) {
     country <- daedalus::daedalus_country(country_name)
     weighted.mean(
       infection$ifr, country$demography
     )
   })
   stringr::str_glue(
-    "A disease with an R0 of { r0 } and an infection fatality ratio of ",
-    "between { ifr_min } and {ifr_max } depending on country",
-    ifr_min = min(country_ifrs),
-    ifr_max = max(country_ifrs),
-    r0 = infection$r0
+    "A disease with an R0 of {r0} and an infection fatality ratio of ",
+    "between {ifr_min_pc}% and {ifr_max_pc}% depending on country",
+    ifr_min_pc = signif(min(country_ifrs) * 100, 2),
+    ifr_max_pc = signif(max(country_ifrs) * 100, 2),
+    r0 = signif(infection$r0, 2)
   )
 }
 

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -81,4 +81,10 @@ test_that("Can get metadata", {
     expect_gte(values$max, values$default)
     expect_gte(values$default, values$min)
   }
+
+  pathogen_idx <- match("pathogen", expected_parameters)
+  pathogen_options <- params[[pathogen_idx]]$options
+  for (option in pathogen_options) {
+    expect_match(option$description, "A disease with R0 of [0-9]")
+  }
 })

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -84,3 +84,50 @@ test_that("calculates correct value of weighted mean of vsl", {
     weighted.mean(mock_country_data$vsl, mock_country_data$demography)
   )
 })
+
+test_that("generates expected pathogen description", {
+  mock_daedalus_infection <- mockery::mock(list(
+    ifr = c(0.1, 0.2, 0.3, 0.4),
+    r0 = 1.72165
+  ))
+  mockery::stub(get_pathogen_description,
+                "daedalus::daedalus_infection",
+                mock_daedalus_infection)
+
+  mockery::stub(get_pathogen_description,
+                "daedalus::country_names",
+                c("Country1", "Country2"))
+
+
+  mock_daedalus_country <- mockery::mock(
+    list(
+      name = "Country1",
+      demography = c(
+        "0-4" = 0.1,
+        "5-19" = 0.2,
+        "20-64" = 0.5,
+        "65+" = 0.2
+      )
+    ),
+    list(
+      name = "Country2",
+      demography = c(
+        "0-4" = 0.2,
+        "5-19" = 0.3,
+        "20-64" = 0.4,
+        "65+" = 0.1
+      )
+    )
+  )
+  mockery::stub(get_pathogen_description,
+                "daedalus::daedalus_country",
+                mock_daedalus_country)
+
+  res <- get_pathogen_description("sars_cov_1")
+  mockery::expect_args(mock_daedalus_infection, 1, "sars_cov_1")
+  expected <- stringr::str_glue(
+    "A disease with R0 of 1.7 and infection fatality ratio between 24% ",
+    "and 28% depending on country"
+  )
+  expect_identical(res, expected)
+})

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -86,48 +86,20 @@ test_that("calculates correct value of weighted mean of vsl", {
 })
 
 test_that("generates expected pathogen description", {
+  ifr <- c(0.1, 0.2, 0.3, 0.4)
   mock_daedalus_infection <- mockery::mock(list(
-    ifr = c(0.1, 0.2, 0.3, 0.4),
+    ifr = ifr,
     r0 = 1.72165
   ))
   mockery::stub(get_pathogen_description,
                 "daedalus::daedalus_infection",
                 mock_daedalus_infection)
 
-  mockery::stub(get_pathogen_description,
-                "daedalus::country_names",
-                c("Country1", "Country2"))
-
-
-  mock_daedalus_country <- mockery::mock(
-    list(
-      name = "Country1",
-      demography = c(
-        "0-4" = 0.1,
-        "5-19" = 0.2,
-        "20-64" = 0.5,
-        "65+" = 0.2
-      )
-    ),
-    list(
-      name = "Country2",
-      demography = c(
-        "0-4" = 0.2,
-        "5-19" = 0.3,
-        "20-64" = 0.4,
-        "65+" = 0.1
-      )
-    )
-  )
-  mockery::stub(get_pathogen_description,
-                "daedalus::daedalus_country",
-                mock_daedalus_country)
-
   res <- get_pathogen_description("sars_cov_1")
   mockery::expect_args(mock_daedalus_infection, 1, "sars_cov_1")
   expected <- stringr::str_glue(
     "A disease with R0 of 1.7 and infection fatality ratio between 24% ",
-    "and 28% depending on country"
+    "and 31% depending on country"
   )
   expect_identical(res, expected)
 })


### PR DESCRIPTION
Adds pathogen descriptions to metadata, to be displayed as help text in the web app. Gets R0 and IFR from the the package, and calculates ifr range for all countries as weighted average across country demographics. Values are rounded to 2 sig figs. 

This generates the following metadata json for the pathogen parameter:
```
{
        "id": "pathogen",
        "label": "Disease",
        "description": "Select a disease to set model parameters for transmissibility, incubation period and severity based on known characteristics of that historical epidemic or epidemic wave",
        "parameterType": "select",
        "ordered": false,
        "options": [
          {
            "id": "sars_cov_1",
            "label": "SARS 2004",
            "description": "A disease with R0 of 1.8 and infection fatality ratio between 3.3% and 7.6% depending on country"
          },
          {
            "id": "sars_cov_2_pre_alpha",
            "label": "Covid-19 wild-type",
            "description": "A disease with R0 of 2.9 and infection fatality ratio between 0.26% and 1.4% depending on country"
          },
          {
            "id": "sars_cov_2_omicron",
            "label": "Covid-19 Omicron",
            "description": "A disease with R0 of 5.9 and infection fatality ratio between 0.11% and 0.62% depending on country"
          },
          {
            "id": "sars_cov_2_delta",
            "label": "Covid-19 Delta",
            "description": "A disease with R0 of 5.1 and infection fatality ratio between 0.47% and 2.5% depending on country"
          },
          {
            "id": "influenza_2009",
            "label": "Influenza 2009 (Swine flu)",
            "description": "A disease with R0 of 1.6 and infection fatality ratio between 0.036% and 0.19% depending on country"
          },
          {
            "id": "influenza_1957",
            "label": "Influenza 1957",
            "description": "A disease with R0 of 1.8 and infection fatality ratio between 0.069% and 0.39% depending on country"
          },
          {
            "id": "influenza_1918",
            "label": "Influenza 1918 (Spanish flu)",
            "description": "A disease with R0 of 2.5 and infection fatality ratio between 0.81% and 1.4% depending on country"
          }
        ]
      }
```