### PR TITLE
jidea-175 update version, and use latest daedalus version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus.api
 Title: Serve the 'daedalus' model via an API
-Version: 0.0.8
+Version: 0.1.0
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),
@@ -12,7 +12,7 @@ License: MIT + file LICENSE
 URL: https://github.com/jameel-institute/daedalus.api
 BugReports: https://github.com/jameel-institute/daedalus.api/issues
 Imports: 
-    daedalus (>= 0.0.22),
+    daedalus (>= 0.0.23),
     docopt,
     dplyr,
     jsonlite,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ License: MIT + file LICENSE
 URL: https://github.com/jameel-institute/daedalus.api
 BugReports: https://github.com/jameel-institute/daedalus.api/issues
 Imports: 
-    daedalus (>= 0.0.23),
+    daedalus (>= 0.1.0),
     docopt,
     dplyr,
     jsonlite,

--- a/docker/build
+++ b/docker/build
@@ -3,7 +3,7 @@ set -ex
 HERE=$(dirname $0)
 . $HERE/common
 
-docker build --pull \
+docker build --pull --progress=plain \
        --tag $TAG_SHA \
        -f docker/Dockerfile \
        .


### PR DESCRIPTION
Use the latest package version, currently 0.0.23
Should wait for 0.1.0 to be merged?

This is currently deployed with the dashboard on dev: https://daedalus-dev.dide.ic.ac.uk (from DIDE network)