### PR TITLE
Use new rrq offload configuration API.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     porcelain,
     R6,
     redux,
-    rrq,
+    rrq (>= 0.7.20),
     stringr,
     tidyr
 Suggests: 
@@ -33,7 +33,7 @@ Suggests:
     withr
 Remotes:
     jameel-institute/daedalus,
-    mrc-ide/rrq,
+    mrc-ide/rrq@mrc-5889,
     reside-ic/porcelain
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/R/main.R
+++ b/R/main.R
@@ -25,15 +25,8 @@ main <- function(args = commandArgs(TRUE)) {
 main_worker <- function() {
   worker <- rrq::rrq_worker$new(
     get_queue_id(),
+    offload_path = get_results_dir(),
     con = get_redis_connection()
   )
   worker$loop()
-}
-
-main_configure_queue <- function() {
-  queue_id <- get_queue_id()
-  rrq::rrq_configure(queue_id,
-                     store_max_size = 1000L,
-                     offload_path = get_results_dir(),
-                     con = get_redis_connection())
 }

--- a/R/queue.R
+++ b/R/queue.R
@@ -18,13 +18,19 @@ Queue <- R6::R6Class("Queue", # nolint
 
       # Configure rrq to store data > 1KB to disk
       queue_id <- get_queue_id()
-      # TODO: Check that the queue is configured, when rrq api is available # nolint
 
       # Create queue
-      self$controller <- rrq::rrq_controller(queue_id, con = con)
+      self$controller <- rrq::rrq_controller(
+        queue_id,
+        offload_threshold_size = 1000L,
+        offload_path = results_dir,
+        con = con)
+
       dir.create(logs_dir, showWarnings = FALSE)
       dir.create(results_dir, showWarnings = FALSE)
-      worker_config <- rrq::rrq_worker_config(logdir = logs_dir)
+      worker_config <- rrq::rrq_worker_config(
+        offload_threshold_size = 1000L,
+        logdir = logs_dir)
       rrq::rrq_worker_config_save("localhost",
                                   worker_config,
                                   controller = self$controller)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,6 @@ COPY . /src
 RUN R CMD INSTALL --install-tests /src && \
         cp /src/docker/daedalus.api /usr/local/bin && \
         cp /src/docker/daedalus.api.worker /usr/local/bin && \
-        cp /src/docker/daedalus.api.configure /usr/local/bin && \
         rm -rf /src
 
 # ENTRYPOINT for api is "/usr/local/bin/daedalus.api"

--- a/docker/daedalus.api.configure
+++ b/docker/daedalus.api.configure
@@ -1,2 +1,0 @@
-#!/usr/bin/env Rscript
-daedalus.api:::main_configure_queue()

--- a/docker/run_containers
+++ b/docker/run_containers
@@ -14,13 +14,6 @@ docker run --rm -d \
   --network=$NAME_NETWORK \
   redis
 
-docker run --rm \
-  --network=$NAME_NETWORK \
-  --env=DAEDALUS_QUEUE_ID=$QUEUE_ID \
-  --env=REDIS_CONTAINER_NAME=$NAME_REDIS \
-  --entrypoint="/usr/local/bin/daedalus.api.configure" \
-  $TAG_SHA
-
 docker run --rm -d \
   -p 8001:8001 \
   --name=$NAME_SERVER \


### PR DESCRIPTION
rrq 0.7.20 has changed a bit how the offload gets configured. Instead of being a global property that must be configured ahead of time, the path to the offload directory is now set per-controller/worker. The offload threshold size is similar, although for workers it is set through the worker configuration.