### PR TITLE
Update for latest daedalus v0.2.26

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,8 +17,8 @@ License: MIT + file LICENSE
 URL: https://github.com/jameel-institute/daedalus.api
 BugReports: https://github.com/jameel-institute/daedalus.api/issues
 Imports: 
-    daedalus (> 0.2.0),
-    daedalus.data,
+    daedalus (> 0.2.25),
+    daedalus.data (>= 0.0.3),
     docopt,
     dplyr,
     jsonlite,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus.api
 Title: Serve the 'daedalus' model via an API
-Version: 0.1.4
+Version: 0.1.5
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),
@@ -17,7 +17,7 @@ License: MIT + file LICENSE
 URL: https://github.com/jameel-institute/daedalus.api
 BugReports: https://github.com/jameel-institute/daedalus.api/issues
 Imports: 
-    daedalus (>= 0.1.0),
+    daedalus (> 0.2.0),
     daedalus.data,
     docopt,
     dplyr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,6 @@ Imports:
 Suggests: 
     httr,
     mockery,
-    spelling,
     testthat (>= 3.0.0),
     uuid,
     withr

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Update `model_run()` daedalus model runner to error if a country hospital capacity <= 0 is passed as this reportedly causes run errors;
 
+- Update `model_run()` to return separate lists for each model NPI;
+
 - Update package to work with _daedalus_ `main` > 0.2.25.
 
 # daedalus.api 0.1.4

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 - Update `model_run()` daedalus model runner to error if a country hospital capacity <= 0 is passed as this reportedly causes run errors;
 
-- Update package to work with _daedalus_ `main`; **NOTE**: not yet working with _daedalus.data_ `main` --- this needs _daedalus_ 0.2.25.
+- Update package to work with _daedalus_ `main` > 0.2.25.
 
 # daedalus.api 0.1.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,9 @@
 
 - Update `model_run()` to return separate lists for each model NPI;
 
-- Update package to work with _daedalus_ `main` > 0.2.25.
+- Update package to work with _daedalus_ `main` > 0.2.25;
+
+- Removing spelling checks from tests.
 
 # daedalus.api 0.1.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# daedalus.api 0.1.5
+
+- Update `model_run()` daedalus model runner to error if a country hospital capacity <= 0 is passed as this reportedly causes run errors;
+
+- Update package to work with _daedalus_ `main`; **NOTE**: not yet working with _daedalus.data_ `main` --- this needs _daedalus_ 0.2.25.
+
 # daedalus.api 0.1.4
 
 - Update metadata for policy responses parameter to denote that this parameter's options are not to be considered as ordered.

--- a/R/model_run.R
+++ b/R/model_run.R
@@ -77,12 +77,19 @@ model_run <- function(parameters, model_version) {
   interventions <- list()
   if (response != "none") {
     closure_info <- model_results$response_data$closure_info
-    closure <- list(
-      id = "response",
-      start = closure_info$closure_times_start,
-      end = closure_info$closure_times_end
+    n_closures <- length(closure_info$closure_durations)
+    closure <- Map(
+      closure_info$closure_times_start,
+      closure_info$closure_times_end,
+      f = function(x, y) {
+        list(
+          id = "response",
+          start = closure_info$closure_times_start,
+          end = closure_info$closure_times_end
+        )
+      }
     )
-    interventions <- list(closure)
+    interventions <- closure
   }
 
   gdp <- get_annual_gdp(country)

--- a/R/model_run.R
+++ b/R/model_run.R
@@ -84,8 +84,8 @@ model_run <- function(parameters, model_version) {
       f = function(x, y) {
         list(
           id = "response",
-          start = closure_info$closure_times_start,
-          end = closure_info$closure_times_end
+          start = x,
+          end = y
         )
       }
     )

--- a/R/model_run.R
+++ b/R/model_run.R
@@ -6,6 +6,11 @@ model_run <- function(parameters, model_version) {
   hospital_capacity <- parameters$hospital_capacity
   hospital_capacity_num <- as.numeric(hospital_capacity)
 
+  # NOTE: this will eventually be replaced with a country class setter method
+  stopifnot(
+    "Hospital capacity must be > 0 but it is not!" = hospital_capacity_num > 0.0
+  )
+
   # manually assign hospital capacity to `country`
   country_obj <- daedalus::daedalus_country(country)
   country_obj$hospital_capacity <- hospital_capacity_num
@@ -74,8 +79,8 @@ model_run <- function(parameters, model_version) {
     closure_info <- model_results$response_data$closure_info
     closure <- list(
       id = "response",
-      start = closure_info$closure_time_start,
-      end = closure_info$closure_time_end
+      start = closure_info$closure_times_start,
+      end = closure_info$closure_times_end
     )
     interventions <- list(closure)
   }

--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ in `porcelain.R`. See the [porcelain docs](https://reside-ic.github.io/porcelain
 
 Redis needs to be running for the e2e tests to pass. Use `./scripts/redis start`, and tear down with `./scripts/redis kill.`
 
+### Testing integration with the dashboard
+
+To test the integration of this package within the entire system including the [dashboard](https://github.com/jameel-institute/daedalus-web-app/), use the [daedalus-deploy](https://github.com/jameel-institute/daedalus-deploy/) tool to install and run all images locally, following the README. You should alter the common config file (`daedalus.yml`) so that the API image tag value points to the feature branch of this package that you want to test, e.g.:
+
+```yml
+# daedalus.yml
+api:
+  image:
+    repo: mrcide
+    name: daedalus.api
+    tag: jidea-297
+```
+
+Ensure that your start-up command uses the `--pull` option so that the deploy tool requests the latest versions of the images. Then visit `https://localhost/` in your browser to do your manual testing (ignoring warnings from your browser that the site is not secure).
+
 ## Model versions
 
 The API should be backwards compatible and support running older versions of the model. 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -3,6 +3,7 @@ Codecov
 GVA
 Jameel
 Latif
+NPI
 ORCID
 RRQ
 Redis

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -9,6 +9,7 @@ RRQ
 Redis
 VSL
 api
+config
 daedalus
 metadata's
 redis

--- a/tests/spelling.R
+++ b/tests/spelling.R
@@ -1,7 +1,0 @@
-if (requireNamespace("spelling", quietly = TRUE)) {
-  spelling::spell_check_test(
-    vignettes = TRUE,
-    error = TRUE,
-    skip_on_cran = TRUE
-  )
-}

--- a/tests/testthat/test_model_run.R
+++ b/tests/testthat/test_model_run.R
@@ -5,8 +5,8 @@ test_that("can run model and return results", {
     model_data = mock_model_data,
     response_data = list(
       closure_info = list(
-        closure_time_start = 11,
-        closure_time_end = 79
+        closure_times_start = 11,
+        closure_times_end = 79
       )
     )
   )


### PR DESCRIPTION
This PR makes a few very small changes to keep _daedalus.api_ working (and the dashboard, I hope):

- Update `model_run()` daedalus model runner to error if a country hospital capacity <= 0 is passed as this reportedly causes run errors;
- Update package to work with _daedalus_ `main` > 0.2.25.