### PR TITLE
Use default hosp cap for behaviour module

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus.api
 Title: Serve the 'daedalus' model via an API
-Version: 0.1.8
+Version: 0.1.9
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# daedalus.api 0.1.9
+
+This patch version prevents the behavioural mechanism from being sensitive to the user-provided hospital capacity. The country default hospital capacity is used instead.
+
 # daedalus.api 0.1.8
 
 This patch version introduces a choice of behavioural model under the user-facing label 'Change in public behaviour' (PR #49).

--- a/R/model_run.R
+++ b/R/model_run.R
@@ -9,18 +9,21 @@ model_run <- function(parameters, model_version) {
   # `behaviour` is passed from the UI as a string that is converted to a
   # `daedalus_new_behaviour()` with some specific parameters in `R/behaviour.R`
   behav_choice_string <- parameters$behaviour
+
+  country_obj <- daedalus::daedalus_country(country)
+
+  # get default hosp cap
+  hosp_cap_default <- daedalus::get_data(country_obj, "hospital_capacity")
   behaviour <- daedalus.api::process_behaviour_choice(
     behav_choice_string,
-    hospital_capacity_num
+    hosp_cap_default
   )
 
   # NOTE: this will eventually be replaced with a country class setter method
   stopifnot(
     "Hospital capacity must be > 0 but it is not!" = hospital_capacity_num > 0.0
   )
-
   # manually assign hospital capacity to `country`
-  country_obj <- daedalus::daedalus_country(country)
   country_obj$hospital_capacity <- hospital_capacity_num
 
   model_results <- daedalus::daedalus(


### PR DESCRIPTION
This issue fixes #51. See the comment on https://github.com/jameel-institute/daedalus/issues/135 for an explanation.