### PR TITLE
Enforce use of daedalus >= 0.3.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus.api
 Title: Serve the 'daedalus' model via an API
-Version: 0.1.9
+Version: 0.1.10
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),
@@ -17,7 +17,7 @@ License: MIT + file LICENSE
 URL: https://github.com/jameel-institute/daedalus.api
 BugReports: https://github.com/jameel-institute/daedalus.api/issues
 Imports: 
-    daedalus (>= 0.3.0),
+    daedalus (>= 0.3.2),
     daedalus.data (>= 0.0.3),
     docopt,
     dplyr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# daedalus.api 0.1.10
+
+This patch version enforces use of _daedalus_ >= v0.3.2 with corrected contact matrix scaling.
+
 # daedalus.api 0.1.9
 
 This patch version prevents the behavioural mechanism from being sensitive to the user-provided hospital capacity. The country default hospital capacity is used instead.


### PR DESCRIPTION
This PR forces the use of daedalus >= 0.3.2, with corrected contact matrix scaling.