### PR TITLE
Prepare for daedalus > 0.3.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ License: MIT + file LICENSE
 URL: https://github.com/jameel-institute/daedalus.api
 BugReports: https://github.com/jameel-institute/daedalus.api/issues
 Imports: 
-    daedalus (> 0.3.6),
+    daedalus (>= 0.3.7),
     daedalus.data (>= 0.0.3),
     docopt,
     dplyr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus.api
 Title: Serve the 'daedalus' model via an API
-Version: 0.1.11
+Version: 0.1.12
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,4 +46,4 @@ Encoding: UTF-8
 Language: en-GB
 Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace",
     "porcelain::porcelain_roclet"))
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ License: MIT + file LICENSE
 URL: https://github.com/jameel-institute/daedalus.api
 BugReports: https://github.com/jameel-institute/daedalus.api/issues
 Imports: 
-    daedalus (>= 0.3.2),
+    daedalus (> 0.3.5),
     daedalus.data (>= 0.0.3),
     docopt,
     dplyr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ License: MIT + file LICENSE
 URL: https://github.com/jameel-institute/daedalus.api
 BugReports: https://github.com/jameel-institute/daedalus.api/issues
 Imports: 
-    daedalus (> 0.3.5),
+    daedalus (> 0.3.6),
     daedalus.data (>= 0.0.3),
     docopt,
     dplyr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# daedalus.api 0.1.12
+
+This patch version enforces use of _daedalus_ > v0.3.5, and adds a call to `daedalus::get_data()` on the model output in the run script `R/model_run.R` to account for changes to the `<daedalus_output>` class in [daedalus PR #156](https://github.com/jameel-institute/daedalus/pull/156).
+
 # daedalus.api 0.1.11
 
 This patch version migrates the building and storing of Docker images from Buildkite to GitHub Container Registry.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # daedalus.api 0.1.12
 
-This patch version enforces use of _daedalus_ > v0.3.5, and adds a call to `daedalus::get_data()` on the model output in the run script `R/model_run.R` to account for changes to the `<daedalus_output>` class in [daedalus PR #156](https://github.com/jameel-institute/daedalus/pull/156).
+This patch version enforces use of _daedalus_ > v0.3.6 (not yet released; see [this PR](https://github.com/jameel-institute/daedalus/pull/154)), which updated community contacts scaling.
+This PR also updates for _daedalus_ > 0.3.5 and adds a call to `daedalus::get_data()` on the model output in the run script `R/model_run.R` to account for changes to the `<daedalus_output>` class in daedalus PR #156.
 
 # daedalus.api 0.1.11
 

--- a/R/model_run.R
+++ b/R/model_run.R
@@ -34,18 +34,13 @@ model_run <- function(parameters, model_version) {
     behaviour = behaviour
   )
 
-  # prevent warnings about global variables
-  compartment <- NULL
-  time <- NULL
-  value <- NULL
-  hospitalised <- NULL
-  hospitalised_recov <- NULL
-  hospitalised_death <- NULL
-  infect_symp <- NULL
-  infect_asymp <- NULL
+  model_data <- daedalus::get_data(model_results)
 
-  time_series <- dplyr::group_by(model_results$model_data, time, compartment)
-  time_series <- dplyr::summarise(time_series, value = sum(value))
+  time_series <- dplyr::summarise(
+    model_data,
+    value = sum(value),
+    .by = c("time", "compartment")
+  )
   time_series <- tidyr::pivot_wider(
     time_series,
     id_cols = "time",
@@ -57,18 +52,16 @@ model_run <- function(parameters, model_version) {
   # separate hospitalisation cols are dropped later during column subsetting
   time_series <- dplyr::mutate(
     time_series,
-    hospitalised = hospitalised_recov + hospitalised_death,
-    prevalence = infect_asymp + infect_symp + hospitalised
+    hospitalised = .data$hospitalised_recov + .data$hospitalised_death,
+    prevalence = .data$infect_asymp + .data$infect_symp + .data$hospitalised
   )
 
   time_series <- time_series[, c("prevalence", "hospitalised", "dead")]
 
   # get total vaccinations time series
-  vaccine_group <- NULL
-  model_data <- daedalus::get_data(model_results)
   vax_time_series <- dplyr::filter(
     model_data,
-    vaccine_group == "vaccinated"
+    .data$vaccine_group == "vaccinated"
   )
   vax_time_series <- dplyr::summarise(
     vax_time_series,


### PR DESCRIPTION
This patch version enforces use of _daedalus_ > v0.3.5 (not yet released; see [daedalus PR #156](https://github.com/jameel-institute/daedalus/pull/156)), and adds a call to `daedalus::get_data()` on the model output in the run script `R/model_run.R` to account for changes to the `<daedalus_output>` class in the linked daedalus PR.

Checks on this PR will fail until daedalus PR 156 is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.1.12
  * Updated daedalus dependency requirement to v> 0.3.6
  * Updated development tooling version

* **Bug Fixes**
  * Fixed script compatibility with updated daedalus versions

* **Documentation**
  * Updated changelog for version 0.1.12

<!-- end of auto-generated comment: release notes by coderabbit.ai -->