### PR TITLE
Model default option changes for Singapore launch

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus.api
 Title: Serve the 'daedalus' model via an API
-Version: 0.1.12
+Version: 0.1.13
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# daedalus.api 0.1.13
+
+This patch version changes the default model options for a dashboard run, and is intended to be used for the READI-TF workshop and launch event.
+
+- Closures are timed and not reactive, and active from 50 -- 200 days;
+
+- All infections have no infection-derived immunity waning, with $\rho$ set to 0.0;
+
+- All vaccination options enforce essentially no immunity waning.
+
 # daedalus.api 0.1.12
 
 This patch version enforces use of _daedalus_ > v0.3.6 (not yet released; see [this PR](https://github.com/jameel-institute/daedalus/pull/154)), which updated community contacts scaling.

--- a/R/model_run.R
+++ b/R/model_run.R
@@ -19,18 +19,42 @@ model_run <- function(parameters, model_version) {
     hosp_cap_default
   )
 
-  # NOTE: this will eventually be replaced with a country class setter method
   stopifnot(
     "Hospital capacity must be > 0 but it is not!" = hospital_capacity_num > 0.0
   )
   # manually assign hospital capacity to `country`
   country_obj$hospital_capacity <- hospital_capacity_num
 
+  # SG launch: set infection to have no immunity waning
+  pathogen_obj <- daedalus::daedalus_infection(
+    pathogen,
+    rho = 0.0
+  )
+
+  # SG launch: create a timed NPI with openness coefs given by `response`
+  start_time <- 50
+  end_time <- 200
+  openness <- daedalus.data::closure_strategy_data[[response]]
+  response_obj <- daedalus::daedalus_timed_npi(
+    start_time,
+    end_time,
+    list(openness),
+    country_obj
+  )
+
+  # SG launch: set vax immunity waning to near zero
+  waning_period_infinite <- 1e8
+  vaccine_obj <- daedalus::daedalus_vaccination(
+    vaccine,
+    country_obj,
+    waning_period = waning_period_infinite
+  )
+
   model_results <- daedalus::daedalus(
     country_obj,
-    pathogen,
-    response_strategy = response,
-    vaccine_investment = vaccine,
+    pathogen_obj,
+    response_strategy = response_obj,
+    vaccine_investment = vaccine_obj,
     behaviour = behaviour
   )
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,3 +1,4 @@
+Buildkite
 CMD
 Codecov
 GVA
@@ -5,8 +6,10 @@ Jameel
 Latif
 NPI
 ORCID
+READI
 RRQ
 Redis
+TF
 VSL
 api
 config

--- a/tests/testthat/test_model_run.R
+++ b/tests/testthat/test_model_run.R
@@ -69,13 +69,27 @@ test_that("can run model and return results", {
   country_x <- daedalus::daedalus_country(ctx)
   country_x$hospital_capacity <- hosp_cap
 
+  time_on <- 50
+  time_off <- 200
+  openness <- list(daedalus.data::closure_strategy_data[["elimination"]])
+  infection <- daedalus::daedalus_infection("influenza_1918", rho = 0.0)
+
   expect_identical(
     mockery::mock_args(mock_daedalus)[[1]],
     list(
       country_x,
-      "influenza_1918",
-      response_strategy = "elimination",
-      vaccine_investment = "high",
+      infection,
+      response_strategy = daedalus::daedalus_timed_npi(
+        time_on,
+        time_off,
+        openness,
+        country_x
+      ),
+      vaccine_investment = daedalus::daedalus_vaccination(
+        "high",
+        country_x,
+        waning_period = 1e8
+      ),
       behaviour = NULL
     )
   )


### PR DESCRIPTION
This patch version changes the default model options for a dashboard run, and is intended to be used for the READI-TF workshop and launch event.
- Closures are timed and not reactive, and active from 50 -- 200 days;
- All infections have no infection-derived immunity waning, with $\rho$ set to 0.0;
- All vaccination options enforce essentially no immunity waning.