### PR TITLE
Reintroduce reactive timings

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: ['*']
   pull_request:
-    branches: [main, master]
+    branches: ['*']
 
 name: R-CMD-check
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: ['*']
   pull_request:
-    branches: [main, master]
+    branches: ['*']
 
 name: test-coverage
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus.api
 Title: Serve the 'daedalus' model via an API
-Version: 0.1.13
+Version: 0.1.14
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/R/model_run.R
+++ b/R/model_run.R
@@ -31,17 +31,6 @@ model_run <- function(parameters, model_version) {
     rho = 0.0
   )
 
-  # SG launch: create a timed NPI with openness coefs given by `response`
-  start_time <- 50
-  end_time <- 200
-  openness <- daedalus.data::closure_strategy_data[[response]]
-  response_obj <- daedalus::daedalus_timed_npi(
-    start_time,
-    end_time,
-    list(openness),
-    country_obj
-  )
-
   # SG launch: set vax immunity waning to near zero
   waning_period_infinite <- 1e8
   vaccine_obj <- daedalus::daedalus_vaccination(
@@ -53,7 +42,7 @@ model_run <- function(parameters, model_version) {
   model_results <- daedalus::daedalus(
     country_obj,
     pathogen_obj,
-    response_strategy = response_obj,
+    response_strategy = response,
     vaccine_investment = vaccine_obj,
     behaviour = behaviour
   )

--- a/tests/testthat/test_model_run.R
+++ b/tests/testthat/test_model_run.R
@@ -69,9 +69,6 @@ test_that("can run model and return results", {
   country_x <- daedalus::daedalus_country(ctx)
   country_x$hospital_capacity <- hosp_cap
 
-  time_on <- 50
-  time_off <- 200
-  openness <- list(daedalus.data::closure_strategy_data[["elimination"]])
   infection <- daedalus::daedalus_infection("influenza_1918", rho = 0.0)
 
   expect_identical(
@@ -79,12 +76,7 @@ test_that("can run model and return results", {
     list(
       country_x,
       infection,
-      response_strategy = daedalus::daedalus_timed_npi(
-        time_on,
-        time_off,
-        openness,
-        country_x
-      ),
+      response_strategy = "elimination",
       vaccine_investment = daedalus::daedalus_vaccination(
         "high",
         country_x,


### PR DESCRIPTION
Branches off readi-tf. I'm creating this out of curiosity to see if the vaccination changes alone are enough to generate nice example scenarios.